### PR TITLE
Add LTC2945 and other I2C device shims from lsst-dcpdu

### DIFF
--- a/rtl/i2c/I2CByteMaster.vhd
+++ b/rtl/i2c/I2CByteMaster.vhd
@@ -14,7 +14,7 @@
 -- File       : I2CByteMaster.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2013-01-22
--- Last update: 2018-08-13
+-- Last update: 2018-08-14
 -------------------------------------------------------------------------------
 -- Description:
 --   PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
@@ -39,278 +39,278 @@ use work.LsstI2cPkg.all;
 
 entity I2CByteMaster is
 
-  generic (
-    TPD_G                : time                      := 1 ns;
-    OUTPUT_EN_POLARITY_G : integer range 0 to 1      := 0;
-    FILTER_G             : integer range 2 to 512    := 8;
-    PRESCALE_G           : integer range 0 to 655535 := 62);
-  port (
-    -- Clock and Reset
-    clk    : in  sl;
-    srst   : in  sl := '0';
-    arst   : in  sl := '0';
-    regIn  : in  I2CByteMasterInType;
-    regOut : out I2CByteMasterOutType;
-    i2ci   : in  i2c_in_type;
-    i2co   : out i2c_out_type
-    );
+   generic (
+      TPD_G                : time                      := 1 ns;
+      OUTPUT_EN_POLARITY_G : integer range 0 to 1      := 0;
+      FILTER_G             : integer range 2 to 512    := 8;
+      PRESCALE_G           : integer range 0 to 655535 := 62);
+   port (
+      -- Clock and Reset
+      clk    : in  sl;
+      srst   : in  sl := '0';
+      arst   : in  sl := '0';
+      regIn  : in  I2CByteMasterInType;
+      regOut : out I2CByteMasterOutType;
+      i2ci   : in  i2c_in_type;
+      i2co   : out i2c_out_type
+      );
 
 end entity I2CByteMaster;
 
 architecture rtl of I2CByteMaster is
 
-  type StateType is (
-    WAIT_REQ_S,
-    ADDR_S,
-    WRITE_S,
-    READ_TXN_S,
-    READ_S,
-    BUS_ACK_S,
-    REG_ACK_S
-    );
+   type StateType is (
+      WAIT_REQ_S,
+      ADDR_S,
+      WRITE_S,
+      READ_TXN_S,
+      READ_S,
+      BUS_ACK_S,
+      REG_ACK_S
+      );
 
-  type RegType is record
-    state         : StateType;
-    AddrbyteCount : unsigned(1 downto 0);
-    byteCount     : unsigned(7 downto 0);
-    DelayDav      : sl;
-    regOut        : I2cByteMasterOutType;
-    i2cMasterIn   : I2cMasterInType;
-  end record RegType;
+   type RegType is record
+      state         : StateType;
+      AddrbyteCount : unsigned(1 downto 0);
+      byteCount     : unsigned(7 downto 0);
+      DelayDav      : sl;
+      regOut        : I2cByteMasterOutType;
+      i2cMasterIn   : I2cMasterInType;
+   end record RegType;
 
-  constant REG_INIT_C : RegType := (
-    state         => WAIT_REQ_S,
-    AddrbyteCount => (others => '0'),
-    byteCount     => (others => '0'),
-    DelayDav      => '0',
-    regOut        => (
-      regAck      => '0',
-      regFail     => '0',
-      regFailCode => (others => '0'),
-      regRdData   => (others => '0'),
-      regRdDav    => '0'),
-    i2cMasterIn   => (
-      enable      => '0',
-      prescale    => (others => '0'),
-      filter      => (others => '0'),
-      txnReq      => '0',
-      stop        => '0',
-      op          => '0',
-      busReq      => '0',
-      addr        => (others => '0'),
-      tenbit      => '0',
-      wrValid     => '0',
-      wrData      => (others => '0'),
-      rdAck       => '0'));
+   constant REG_INIT_C : RegType := (
+      state          => WAIT_REQ_S,
+      AddrbyteCount  => (others => '0'),
+      byteCount      => (others => '0'),
+      DelayDav       => '0',
+      regOut         => (
+         regAck      => '0',
+         regFail     => '0',
+         regFailCode => (others => '0'),
+         regRdData   => (others => '0'),
+         regRdDav    => '0'),
+      i2cMasterIn    => (
+         enable      => '0',
+         prescale    => (others => '0'),
+         filter      => (others => '0'),
+         txnReq      => '0',
+         stop        => '0',
+         op          => '0',
+         busReq      => '0',
+         addr        => (others => '0'),
+         tenbit      => '0',
+         wrValid     => '0',
+         wrData      => (others => '0'),
+         rdAck       => '0'));
 
-  signal r            : RegType := REG_INIT_C;
-  signal rin          : RegType;
-  signal i2cMasterIn  : I2cMasterInType;
-  signal i2cMasterOut : I2cMasterOutType;
+   signal r            : RegType := REG_INIT_C;
+   signal rin          : RegType;
+   signal i2cMasterIn  : I2cMasterInType;
+   signal i2cMasterOut : I2cMasterOutType;
 
-  function getIndex (
-    endianness : sl;
-    byteCount  : unsigned;
-    totalBytes : unsigned)
-    return integer is
-  begin
-    if (endianness = '0') then
-      -- little endian
-      return to_integer(byteCount)*8;
-    else
-      -- big endian
-      return (to_integer(totalBytes)-to_integer(byteCount))*8;
-    end if;
-  end function getIndex;
+   function getIndex (
+      endianness : sl;
+      byteCount  : unsigned;
+      totalBytes : unsigned)
+      return integer is
+   begin
+      if (endianness = '0') then
+         -- little endian
+         return to_integer(byteCount)*8;
+      else
+         -- big endian
+         return (to_integer(totalBytes)-to_integer(byteCount))*8;
+      end if;
+   end function getIndex;
 
 begin
 
-  i2cMaster_1 : entity work.I2cMaster
-    generic map (
-      TPD_G                => TPD_G,
-      OUTPUT_EN_POLARITY_G => OUTPUT_EN_POLARITY_G,
-      FILTER_G             => FILTER_G,
-      DYNAMIC_FILTER_G     => 0)
-    port map (
-      clk          => clk,
-      srst         => srst,
-      arst         => arst,
-      i2cMasterIn  => i2cMasterIn,
-      i2cMasterOut => i2cMasterOut,
-      i2ci         => i2ci,
-      i2co         => i2co
-      );
+   i2cMaster_1 : entity work.I2cMaster
+      generic map (
+         TPD_G                => TPD_G,
+         OUTPUT_EN_POLARITY_G => OUTPUT_EN_POLARITY_G,
+         FILTER_G             => FILTER_G,
+         DYNAMIC_FILTER_G     => 0)
+      port map (
+         clk          => clk,
+         srst         => srst,
+         arst         => arst,
+         i2cMasterIn  => i2cMasterIn,
+         i2cMasterOut => i2cMasterOut,
+         i2ci         => i2ci,
+         i2co         => i2co
+         );
 
-  comb : process (regIn, i2cMasterOut, r, srst) is
-    variable v            : RegType;
-    variable addrIndexVar : integer;
-    variable dataIndexVar : integer;
-  begin
-    v := r;
+   comb : process (regIn, i2cMasterOut, r, srst) is
+      variable v            : RegType;
+      variable addrIndexVar : integer;
+      variable dataIndexVar : integer;
+   begin
+      v := r;
 
-    addrIndexVar := getIndex(regIn.endianness, r.AddrbyteCount, unsigned(regIn.regAddrSize));
-    dataIndexVar := getIndex(regIn.endianness, r.byteCount, unsigned(regIn.regDataSize));
+      addrIndexVar := getIndex(regIn.endianness, r.AddrbyteCount, unsigned(regIn.regAddrSize));
+      dataIndexVar := getIndex(regIn.endianness, r.byteCount, unsigned(regIn.regDataSize));
 
-    v.regOut.regAck  := '0';
-    v.regOut.regFail := '0';
-    v.regOut.regRdDav       := r.DelayDav;
-    v.DelayDav       := '0';
+      v.regOut.regAck   := '0';
+      v.regOut.regFail  := '0';
+      v.regOut.regRdDav := r.DelayDav;
+      v.DelayDav        := '0';
 
-    v.i2cMasterIn.rdAck := '0';
+      v.i2cMasterIn.rdAck := '0';
 
-    case r.state is
-      when WAIT_REQ_S =>
-        v.byteCount     := (others => '0');
-        v.AddrbyteCount := (others => '0');
-        if (regIn.regReq = '1') then
-          v.i2cMasterIn.txnReq := '1';
-          v.i2cMasterIn.op     := '1';
-          -- Use a repeated start for reads when directed to do so
-          -- This is done by setting stop to 0 for the regAddr write txn
-          -- Then the following read txn will be issued with repeated start
-          v.i2cMasterIn.stop   := ite(regIn.regOp = '0' and regIn.repeatStart = '1', '0', '1');
-          v.i2cMasterIn.busReq := regIn.busReq;
-          v.state              := ADDR_S;
-          if regIn.busReq = '1' then
-            v.state := BUS_ACK_S;
-          elsif (regIn.regAddrSkip = '1') then
-            if (regIn.regOp = '1') then
-              v.state := WRITE_S;
-            else
-              v.i2cMasterIn.op := '0';
-              v.state          := READ_S;
+      case r.state is
+         when WAIT_REQ_S =>
+            v.byteCount     := (others => '0');
+            v.AddrbyteCount := (others => '0');
+            if (regIn.regReq = '1') then
+               v.i2cMasterIn.txnReq := '1';
+               v.i2cMasterIn.op     := '1';
+               -- Use a repeated start for reads when directed to do so
+               -- This is done by setting stop to 0 for the regAddr write txn
+               -- Then the following read txn will be issued with repeated start
+               v.i2cMasterIn.stop   := ite(regIn.regOp = '0' and regIn.repeatStart = '1', '0', '1');
+               v.i2cMasterIn.busReq := regIn.busReq;
+               v.state              := ADDR_S;
+               if regIn.busReq = '1' then
+                  v.state := BUS_ACK_S;
+               elsif (regIn.regAddrSkip = '1') then
+                  if (regIn.regOp = '1') then
+                     v.state := WRITE_S;
+                  else
+                     v.i2cMasterIn.op := '0';
+                     v.state          := READ_S;
+                  end if;
+               end if;
             end if;
-          end if;
-        end if;
 
-      when ADDR_S =>
-        -- When a new register access request is seen,
-        -- Write the register address out on the bus first
-        -- One byte at a time, order determined by endianness input
-        v.i2cMasterIn.wrData  := regIn.regAddr(addrIndexVar+7 downto addrIndexVar);
-        v.i2cMasterIn.wrValid := '1';
-        -- Must drop txnReq as last byte is sent if reading
-        v.i2cMasterIn.txnReq  := not toSl(slv(r.AddrbyteCount) = regIn.regAddrSize and regIn.regOp = '0');
+         when ADDR_S =>
+            -- When a new register access request is seen,
+            -- Write the register address out on the bus first
+            -- One byte at a time, order determined by endianness input
+            v.i2cMasterIn.wrData  := regIn.regAddr(addrIndexVar+7 downto addrIndexVar);
+            v.i2cMasterIn.wrValid := '1';
+            -- Must drop txnReq as last byte is sent if reading
+            v.i2cMasterIn.txnReq  := not toSl(slv(r.AddrbyteCount) = regIn.regAddrSize and regIn.regOp = '0');
 
-        if (i2cMasterOut.wrAck = '1') then
-          v.AddrbyteCount       := r.AddrbyteCount + 1;
-          v.i2cMasterIn.wrValid := '0';
-          if (slv(r.AddrbyteCount) = regIn.regAddrSize) then
-            -- Done sending addr
-            v.byteCount := (others => '0');
-            if (regIn.regOp = '1') then
-              v.state := WRITE_S;
-            else
-              v.state := READ_TXN_S;
+            if (i2cMasterOut.wrAck = '1') then
+               v.AddrbyteCount       := r.AddrbyteCount + 1;
+               v.i2cMasterIn.wrValid := '0';
+               if (slv(r.AddrbyteCount) = regIn.regAddrSize) then
+                  -- Done sending addr
+                  v.byteCount := (others => '0');
+                  if (regIn.regOp = '1') then
+                     v.state := WRITE_S;
+                  else
+                     v.state := READ_TXN_S;
+                  end if;
+               end if;
             end if;
-          end if;
-        end if;
 
-      when WRITE_S =>
-        -- Txn started in WAIT_REQ_S still active
-        -- Put wrData on the bus one byte at a time
-        v.i2cMasterIn.wrData  := regIn.regWrData(dataIndexVar+7 downto dataIndexVar);
-        v.i2cMasterIn.wrValid := '1';
-        v.i2cMasterIn.txnReq  := not toSl(slv(r.byteCount) = regIn.regDataSize);
-        v.i2cMasterIn.stop    := '1';  -- Send stop when done writing all bytes
-        if (i2cMasterOut.wrAck = '1') then
-          v.byteCount           := r.byteCount + 1;
-          v.i2cMasterIn.wrValid := '0';
-          if (slv(r.byteCount) = regIn.regDataSize) then  -- could use rxnReq = 0
-            v.state := REG_ACK_S;
-          end if;
-        end if;
+         when WRITE_S =>
+            -- Txn started in WAIT_REQ_S still active
+            -- Put wrData on the bus one byte at a time
+            v.i2cMasterIn.wrData  := regIn.regWrData(dataIndexVar+7 downto dataIndexVar);
+            v.i2cMasterIn.wrValid := '1';
+            v.i2cMasterIn.txnReq  := not toSl(slv(r.byteCount) = regIn.regDataSize);
+            v.i2cMasterIn.stop    := '1';  -- Send stop when done writing all bytes
+            if (i2cMasterOut.wrAck = '1') then
+               v.byteCount           := r.byteCount + 1;
+               v.i2cMasterIn.wrValid := '0';
+               if (slv(r.byteCount) = regIn.regDataSize) then  -- could use rxnReq = 0
+                  v.state := REG_ACK_S;
+               end if;
+            end if;
 
 
-      when READ_TXN_S =>
-        -- Start new txn to read data bytes
-        v.i2cMasterIn.txnReq := '1';
-        v.i2cMasterIn.op     := '0';
-        v.i2cMasterIn.stop   := '1';    -- i2c stop after all bytes are read
-        v.state              := READ_S;
+         when READ_TXN_S =>
+            -- Start new txn to read data bytes
+            v.i2cMasterIn.txnReq := '1';
+            v.i2cMasterIn.op     := '0';
+            v.i2cMasterIn.stop   := '1';  -- i2c stop after all bytes are read
+            v.state              := READ_S;
 
-      when READ_S =>
-        -- Drop txnReq on last byte
-        v.i2cMasterIn.txnReq := not toSl(slv(r.byteCount) = regIn.regDataSize);
-        -- Read data bytes as they arrive
-        if (i2cMasterOut.rdValid = '1' and r.i2cMasterIn.rdAck = '0') then
-          v.byteCount         := r.byteCount + 1;
-          v.regOut.regRdData  := i2cMasterOut.rdData;
-          v.DelayDav          := '1';
-          v.i2cMasterIn.rdAck := '1';
-          if (slv(r.byteCount) = regIn.regDataSize) then
-            -- Done
-            v.state := REG_ACK_S;
-          end if;
-        end if;
+         when READ_S =>
+            -- Drop txnReq on last byte
+            v.i2cMasterIn.txnReq := not toSl(slv(r.byteCount) = regIn.regDataSize);
+            -- Read data bytes as they arrive
+            if (i2cMasterOut.rdValid = '1' and r.i2cMasterIn.rdAck = '0') then
+               v.byteCount         := r.byteCount + 1;
+               v.regOut.regRdData  := i2cMasterOut.rdData;
+               v.DelayDav          := '1';
+               v.i2cMasterIn.rdAck := '1';
+               if (slv(r.byteCount) = regIn.regDataSize) then
+                  -- Done
+                  v.state := REG_ACK_S;
+               end if;
+            end if;
 
-      when BUS_ACK_S =>
-        if i2cMasterOut.busAck = '1' then
-          v.i2cMasterIn.txnReq := '0';
-          v.state              := REG_ACK_S;
-        end if;
+         when BUS_ACK_S =>
+            if i2cMasterOut.busAck = '1' then
+               v.i2cMasterIn.txnReq := '0';
+               v.state              := REG_ACK_S;
+            end if;
 
-      when REG_ACK_S =>
-        -- Req done. Ack the req.
-        -- Might have failed so hold regFail (would be set to 0 otherwise).
-        v.regOut.regAck  := '1';
-        v.regOut.regFail := r.regOut.regFail;
-        if (regIn.regReq = '0') then
+         when REG_ACK_S =>
+            -- Req done. Ack the req.
+            -- Might have failed so hold regFail (would be set to 0 otherwise).
+            v.regOut.regAck  := '1';
+            v.regOut.regFail := r.regOut.regFail;
+            if (regIn.regReq = '0') then
 --          v.regOut.regAck := '0'; Might want this back. 
-          v.state := WAIT_REQ_S;
-        end if;
+               v.state := WAIT_REQ_S;
+            end if;
 
-    end case;
+      end case;
 
-    -- Always check for errors an cancel the txn if they happen
-    if (i2cMasterOut.txnError = '1' and i2cMasterOut.rdValid = '1') then
-      v.regOut.regFail     := '1';
-      v.regOut.regFailCode := i2cMasterOut.rdData;
-      v.i2cMasterIn.txnReq := '0';
-      v.i2cMasterIn.rdAck  := '1';
-      v.state              := REG_ACK_S;
-    end if;
+      -- Always check for errors an cancel the txn if they happen
+      if (i2cMasterOut.txnError = '1' and i2cMasterOut.rdValid = '1') then
+         v.regOut.regFail     := '1';
+         v.regOut.regFailCode := i2cMasterOut.rdData;
+         v.i2cMasterIn.txnReq := '0';
+         v.i2cMasterIn.rdAck  := '1';
+         v.state              := REG_ACK_S;
+      end if;
 
-    ------------------------------------------------------------------------------------------------
-    -- Synchronous Reset
-    ------------------------------------------------------------------------------------------------
-    if (srst = '1') then
-      v := REG_INIT_C;
-    end if;
+      ------------------------------------------------------------------------------------------------
+      -- Synchronous Reset
+      ------------------------------------------------------------------------------------------------
+      if (srst = '1') then
+         v := REG_INIT_C;
+      end if;
 
-    ------------------------------------------------------------------------------------------------
-    -- Signal Assignments
-    ------------------------------------------------------------------------------------------------
-    -- Update registers
-    rin <= v;
+      ------------------------------------------------------------------------------------------------
+      -- Signal Assignments
+      ------------------------------------------------------------------------------------------------
+      -- Update registers
+      rin <= v;
 
-    -- Internal signals
-    i2cMasterIn.enable   <= '1';
-    i2cMasterIn.prescale <= slv(to_unsigned(PRESCALE_G, 16));
-    i2cMasterIn.filter   <= (others => '0');  -- Not using dynamic filtering
-    i2cMasterIn.addr     <= regIn.i2cAddr;
-    i2cMasterIn.tenbit   <= regIn.tenbit;
-    i2cMasterIn.txnReq   <= r.i2cMasterIn.txnReq;
-    i2cMasterIn.stop     <= r.i2cMasterIn.stop;
-    i2cMasterIn.op       <= r.i2cMasterIn.op;
-    i2cMasterIn.wrValid  <= r.i2cMasterIn.wrValid;
-    i2cMasterIn.wrData   <= r.i2cMasterIn.wrData;
-    i2cMasterIn.rdAck    <= r.i2cMasterIn.rdAck;
-    i2cMasterIn.busReq   <= r.i2cMasterIn.busReq;
+      -- Internal signals
+      i2cMasterIn.enable   <= '1';
+      i2cMasterIn.prescale <= slv(to_unsigned(PRESCALE_G, 16));
+      i2cMasterIn.filter   <= (others => '0');  -- Not using dynamic filtering
+      i2cMasterIn.addr     <= regIn.i2cAddr;
+      i2cMasterIn.tenbit   <= regIn.tenbit;
+      i2cMasterIn.txnReq   <= r.i2cMasterIn.txnReq;
+      i2cMasterIn.stop     <= r.i2cMasterIn.stop;
+      i2cMasterIn.op       <= r.i2cMasterIn.op;
+      i2cMasterIn.wrValid  <= r.i2cMasterIn.wrValid;
+      i2cMasterIn.wrData   <= r.i2cMasterIn.wrData;
+      i2cMasterIn.rdAck    <= r.i2cMasterIn.rdAck;
+      i2cMasterIn.busReq   <= r.i2cMasterIn.busReq;
 
-    -- Outputs
-    regOut <= r.regOut;
+      -- Outputs
+      regOut <= r.regOut;
 
-  end process comb;
+   end process comb;
 
-  seq : process (clk, arst) is
-  begin
-    if (arst = '1') then
-      r <= REG_INIT_C after TPD_G;
-    elsif (rising_edge(clk)) then
-      r <= rin after TPD_G;
-    end if;
-  end process seq;
+   seq : process (clk, arst) is
+   begin
+      if (arst = '1') then
+         r <= REG_INIT_C after TPD_G;
+      elsif (rising_edge(clk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
 
 
 

--- a/rtl/i2c/I2CByteMaster.vhd
+++ b/rtl/i2c/I2CByteMaster.vhd
@@ -1,0 +1,317 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      I2CByteMaster.vhd -
+--
+--      Copyright(c) SLAC National Accelerator Laboratory 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 3/13/2018 1:25:59 PM
+--      Last change: JO 3/15/2018 5:24:37 PM
+--
+-------------------------------------------------------------------------------
+-- File       : I2CByteMaster.vhd
+-- Company    : SLAC National Accelerator Laboratory
+-- Created    : 2013-01-22
+-- Last update: 2018-08-13
+-------------------------------------------------------------------------------
+-- Description:
+--   PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
+--   FILTER_G = (min_pulse_time / clk_period) + 1
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'SLAC Firmware Standard Library', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.StdRtlPkg.all;
+use work.I2cPkg.all;
+use work.LsstI2cPkg.all;
+
+entity I2CByteMaster is
+
+  generic (
+    TPD_G                : time                      := 1 ns;
+    OUTPUT_EN_POLARITY_G : integer range 0 to 1      := 0;
+    FILTER_G             : integer range 2 to 512    := 8;
+    PRESCALE_G           : integer range 0 to 655535 := 62);
+  port (
+    -- Clock and Reset
+    clk    : in  sl;
+    srst   : in  sl := '0';
+    arst   : in  sl := '0';
+    regIn  : in  I2CByteMasterInType;
+    regOut : out I2CByteMasterOutType;
+    i2ci   : in  i2c_in_type;
+    i2co   : out i2c_out_type
+    );
+
+end entity I2CByteMaster;
+
+architecture rtl of I2CByteMaster is
+
+  type StateType is (
+    WAIT_REQ_S,
+    ADDR_S,
+    WRITE_S,
+    READ_TXN_S,
+    READ_S,
+    BUS_ACK_S,
+    REG_ACK_S
+    );
+
+  type RegType is record
+    state         : StateType;
+    AddrbyteCount : unsigned(1 downto 0);
+    byteCount     : unsigned(7 downto 0);
+    DelayDav      : sl;
+    regOut        : I2cByteMasterOutType;
+    i2cMasterIn   : I2cMasterInType;
+  end record RegType;
+
+  constant REG_INIT_C : RegType := (
+    state         => WAIT_REQ_S,
+    AddrbyteCount => (others => '0'),
+    byteCount     => (others => '0'),
+    DelayDav      => '0',
+    regOut        => (
+      regAck      => '0',
+      regFail     => '0',
+      regFailCode => (others => '0'),
+      regRdData   => (others => '0'),
+      regRdDav    => '0'),
+    i2cMasterIn   => (
+      enable      => '0',
+      prescale    => (others => '0'),
+      filter      => (others => '0'),
+      txnReq      => '0',
+      stop        => '0',
+      op          => '0',
+      busReq      => '0',
+      addr        => (others => '0'),
+      tenbit      => '0',
+      wrValid     => '0',
+      wrData      => (others => '0'),
+      rdAck       => '0'));
+
+  signal r            : RegType := REG_INIT_C;
+  signal rin          : RegType;
+  signal i2cMasterIn  : I2cMasterInType;
+  signal i2cMasterOut : I2cMasterOutType;
+
+  function getIndex (
+    endianness : sl;
+    byteCount  : unsigned;
+    totalBytes : unsigned)
+    return integer is
+  begin
+    if (endianness = '0') then
+      -- little endian
+      return to_integer(byteCount)*8;
+    else
+      -- big endian
+      return (to_integer(totalBytes)-to_integer(byteCount))*8;
+    end if;
+  end function getIndex;
+
+begin
+
+  i2cMaster_1 : entity work.I2cMaster
+    generic map (
+      TPD_G                => TPD_G,
+      OUTPUT_EN_POLARITY_G => OUTPUT_EN_POLARITY_G,
+      FILTER_G             => FILTER_G,
+      DYNAMIC_FILTER_G     => 0)
+    port map (
+      clk          => clk,
+      srst         => srst,
+      arst         => arst,
+      i2cMasterIn  => i2cMasterIn,
+      i2cMasterOut => i2cMasterOut,
+      i2ci         => i2ci,
+      i2co         => i2co
+      );
+
+  comb : process (regIn, i2cMasterOut, r, srst) is
+    variable v            : RegType;
+    variable addrIndexVar : integer;
+    variable dataIndexVar : integer;
+  begin
+    v := r;
+
+    addrIndexVar := getIndex(regIn.endianness, r.AddrbyteCount, unsigned(regIn.regAddrSize));
+    dataIndexVar := getIndex(regIn.endianness, r.byteCount, unsigned(regIn.regDataSize));
+
+    v.regOut.regAck  := '0';
+    v.regOut.regFail := '0';
+    v.regOut.regRdDav       := r.DelayDav;
+    v.DelayDav       := '0';
+
+    v.i2cMasterIn.rdAck := '0';
+
+    case r.state is
+      when WAIT_REQ_S =>
+        v.byteCount     := (others => '0');
+        v.AddrbyteCount := (others => '0');
+        if (regIn.regReq = '1') then
+          v.i2cMasterIn.txnReq := '1';
+          v.i2cMasterIn.op     := '1';
+          -- Use a repeated start for reads when directed to do so
+          -- This is done by setting stop to 0 for the regAddr write txn
+          -- Then the following read txn will be issued with repeated start
+          v.i2cMasterIn.stop   := ite(regIn.regOp = '0' and regIn.repeatStart = '1', '0', '1');
+          v.i2cMasterIn.busReq := regIn.busReq;
+          v.state              := ADDR_S;
+          if regIn.busReq = '1' then
+            v.state := BUS_ACK_S;
+          elsif (regIn.regAddrSkip = '1') then
+            if (regIn.regOp = '1') then
+              v.state := WRITE_S;
+            else
+              v.i2cMasterIn.op := '0';
+              v.state          := READ_S;
+            end if;
+          end if;
+        end if;
+
+      when ADDR_S =>
+        -- When a new register access request is seen,
+        -- Write the register address out on the bus first
+        -- One byte at a time, order determined by endianness input
+        v.i2cMasterIn.wrData  := regIn.regAddr(addrIndexVar+7 downto addrIndexVar);
+        v.i2cMasterIn.wrValid := '1';
+        -- Must drop txnReq as last byte is sent if reading
+        v.i2cMasterIn.txnReq  := not toSl(slv(r.AddrbyteCount) = regIn.regAddrSize and regIn.regOp = '0');
+
+        if (i2cMasterOut.wrAck = '1') then
+          v.AddrbyteCount       := r.AddrbyteCount + 1;
+          v.i2cMasterIn.wrValid := '0';
+          if (slv(r.AddrbyteCount) = regIn.regAddrSize) then
+            -- Done sending addr
+            v.byteCount := (others => '0');
+            if (regIn.regOp = '1') then
+              v.state := WRITE_S;
+            else
+              v.state := READ_TXN_S;
+            end if;
+          end if;
+        end if;
+
+      when WRITE_S =>
+        -- Txn started in WAIT_REQ_S still active
+        -- Put wrData on the bus one byte at a time
+        v.i2cMasterIn.wrData  := regIn.regWrData(dataIndexVar+7 downto dataIndexVar);
+        v.i2cMasterIn.wrValid := '1';
+        v.i2cMasterIn.txnReq  := not toSl(slv(r.byteCount) = regIn.regDataSize);
+        v.i2cMasterIn.stop    := '1';  -- Send stop when done writing all bytes
+        if (i2cMasterOut.wrAck = '1') then
+          v.byteCount           := r.byteCount + 1;
+          v.i2cMasterIn.wrValid := '0';
+          if (slv(r.byteCount) = regIn.regDataSize) then  -- could use rxnReq = 0
+            v.state := REG_ACK_S;
+          end if;
+        end if;
+
+
+      when READ_TXN_S =>
+        -- Start new txn to read data bytes
+        v.i2cMasterIn.txnReq := '1';
+        v.i2cMasterIn.op     := '0';
+        v.i2cMasterIn.stop   := '1';    -- i2c stop after all bytes are read
+        v.state              := READ_S;
+
+      when READ_S =>
+        -- Drop txnReq on last byte
+        v.i2cMasterIn.txnReq := not toSl(slv(r.byteCount) = regIn.regDataSize);
+        -- Read data bytes as they arrive
+        if (i2cMasterOut.rdValid = '1' and r.i2cMasterIn.rdAck = '0') then
+          v.byteCount         := r.byteCount + 1;
+          v.regOut.regRdData  := i2cMasterOut.rdData;
+          v.DelayDav          := '1';
+          v.i2cMasterIn.rdAck := '1';
+          if (slv(r.byteCount) = regIn.regDataSize) then
+            -- Done
+            v.state := REG_ACK_S;
+          end if;
+        end if;
+
+      when BUS_ACK_S =>
+        if i2cMasterOut.busAck = '1' then
+          v.i2cMasterIn.txnReq := '0';
+          v.state              := REG_ACK_S;
+        end if;
+
+      when REG_ACK_S =>
+        -- Req done. Ack the req.
+        -- Might have failed so hold regFail (would be set to 0 otherwise).
+        v.regOut.regAck  := '1';
+        v.regOut.regFail := r.regOut.regFail;
+        if (regIn.regReq = '0') then
+--          v.regOut.regAck := '0'; Might want this back. 
+          v.state := WAIT_REQ_S;
+        end if;
+
+    end case;
+
+    -- Always check for errors an cancel the txn if they happen
+    if (i2cMasterOut.txnError = '1' and i2cMasterOut.rdValid = '1') then
+      v.regOut.regFail     := '1';
+      v.regOut.regFailCode := i2cMasterOut.rdData;
+      v.i2cMasterIn.txnReq := '0';
+      v.i2cMasterIn.rdAck  := '1';
+      v.state              := REG_ACK_S;
+    end if;
+
+    ------------------------------------------------------------------------------------------------
+    -- Synchronous Reset
+    ------------------------------------------------------------------------------------------------
+    if (srst = '1') then
+      v := REG_INIT_C;
+    end if;
+
+    ------------------------------------------------------------------------------------------------
+    -- Signal Assignments
+    ------------------------------------------------------------------------------------------------
+    -- Update registers
+    rin <= v;
+
+    -- Internal signals
+    i2cMasterIn.enable   <= '1';
+    i2cMasterIn.prescale <= slv(to_unsigned(PRESCALE_G, 16));
+    i2cMasterIn.filter   <= (others => '0');  -- Not using dynamic filtering
+    i2cMasterIn.addr     <= regIn.i2cAddr;
+    i2cMasterIn.tenbit   <= regIn.tenbit;
+    i2cMasterIn.txnReq   <= r.i2cMasterIn.txnReq;
+    i2cMasterIn.stop     <= r.i2cMasterIn.stop;
+    i2cMasterIn.op       <= r.i2cMasterIn.op;
+    i2cMasterIn.wrValid  <= r.i2cMasterIn.wrValid;
+    i2cMasterIn.wrData   <= r.i2cMasterIn.wrData;
+    i2cMasterIn.rdAck    <= r.i2cMasterIn.rdAck;
+    i2cMasterIn.busReq   <= r.i2cMasterIn.busReq;
+
+    -- Outputs
+    regOut <= r.regOut;
+
+  end process comb;
+
+  seq : process (clk, arst) is
+  begin
+    if (arst = '1') then
+      r <= REG_INIT_C after TPD_G;
+    elsif (rising_edge(clk)) then
+      r <= rin after TPD_G;
+    end if;
+  end process seq;
+
+
+
+end architecture rtl;

--- a/rtl/i2c/LTC2945Axil.vhd
+++ b/rtl/i2c/LTC2945Axil.vhd
@@ -1,0 +1,170 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      LTC2945Axil.vhd - 
+--
+--      Copyright(c) SLAC National Accelerator Laboratory 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/14/2018 8:56:03 AM
+--      Last change: JO 4/18/2018 3:41:44 PM
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+
+use work.StdRtlPkg.all;
+use work.AxiStreamPkg.all;
+use work.AxiLitePkg.all;
+use work.I2cPkg.all;
+
+entity LTC2945Axil is
+   generic (
+      TPD_G           : time             := 1 ns);
+   port (
+      -- AXI-Lite Interface
+      axilClk         : in    sl;
+      axilRst         : in    sl;
+      axilReadMaster  : in    AxiLiteReadMasterType;
+      axilReadSlave   : out   AxiLiteReadSlaveType;
+      axilWriteMaster : in    AxiLiteWriteMasterType;
+      axilWriteSlave  : out   AxiLiteWriteSlaveType;
+      -- I2C bus
+      i2ci            : inout i2c_in_type;
+      i2co            : inout i2c_out_type;
+      -- Start Conversion
+      StartConv       : in    sl;
+      -- I2C fault
+      LTC2945ComFault : out   sl
+      );
+end entity LTC2945Axil;
+
+architecture Behavioral of LTC2945Axil is
+
+   type RegType is record
+      ADCReadStart   : sl;
+      FifoWr         : sl;
+      RdDelay        : sl;
+      axilReadSlave  : AxiLiteReadSlaveType;
+      axilWriteSlave : AxiLiteWriteSlaveType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      ADCReadStart   => '0',
+      FifoWr         => '0',
+      RdDelay        => '0',
+      axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+      axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
+
+   signal r          : RegType := REG_INIT_C;
+   signal rin        : RegType;
+   signal FifoDataIn : slv(31 downto 0);
+   signal LTCDataOut : slv(31 downto 0);
+   signal Convert    : sl;
+
+begin
+
+   comb : process (LTCDataOut, axilReadMaster, axilRst, axilWriteMaster, r) is
+      variable v          : RegType;
+      variable axilStatus : AxiLiteStatusType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Reset the strobes
+      v.ADCReadStart := '0';
+      v.FifoWr       := '0';
+      v.RdDelay      := '0';
+
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
+
+      -- Check for a write request
+      if (axilStatus.writeEnable = '1') then
+         -- Check for start
+         if (axilWriteMaster.awaddr(11 downto 0) = x"100") then
+            v.ADCReadStart := '1';
+         elsif (axilWriteMaster.awaddr(11 downto 0) < x"100") then
+            v.FifoWr := '1';
+         end if;
+         -- Send AXI-Lite Response
+         axiSlaveWriteResponse(v.axilWriteSlave, AXI_RESP_OK_C);
+      end if;
+
+      -- Check for a read request
+      if (axilStatus.readEnable = '1') then
+         -- Wait 1 cycle for data to get out of the DPMEM pipeline
+         v.RdDelay := '1';
+      end if;
+
+      if (r.RdDelay = '1') then
+         -- Forward the read data from the RAM
+         v.axilReadSlave.rdata := LTCDataOut;
+         -- Send AXI-Lite Response
+         axiSlaveReadResponse(v.axilReadSlave, AXI_RESP_OK_C);
+      end if;
+
+      -- Reset
+      if (axilRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+      -- Outputs 
+      axilReadSlave  <= r.axilReadSlave;
+      axilWriteSlave <= r.axilWriteSlave;
+
+      -- Fifo Data is the address and 24 bit data to the ADC which
+      -- becomes the ADC register and 24 bit data to write
+      FifoDataIn <= axilWriteMaster.awaddr(9 downto 2) & axilWriteMaster.wdata(23 downto 0);
+
+   end process;
+
+   seq : process (axilClk) is
+   begin
+      if (rising_edge(axilClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   u_LTC2945 : entity work.LTC2945I2CCore
+      generic map (
+         TPD_G           => 1 ns,
+         ADDR_WIDTH_G    => 8,
+         POLL_TIMEOUT_G  => 16,
+         I2C_ADDR_G      => "1101111",  -- LTC Addr1, Addr0 = "00"
+         I2C_SCL_FREQ_G  => 100.0E+3,   -- units of Hz
+         I2C_MIN_PULSE_G => 100.0E-9    -- units of seconds
+         )
+      port map (
+         Clock           => axilClk,
+         Reset           => axilRst,
+--      StartRead => r.ADCReadStart,
+         StartRead       => StartConv,
+         -- Serial interface
+         i2ci            => i2ci,
+         i2co            => i2co,
+         -- Fifo Interface for writes
+         WrStrb          => r.FifoWr,
+         DataIn          => FifoDataIn,
+         -- Dual Port memory for output
+         RdMemAddr       => axilReadMaster.araddr(6 downto 2),
+         MemDout         => LTCDataOut,
+         LTC2945ComFault => LTC2945ComFault
+         );
+
+end;
+

--- a/rtl/i2c/LTC2945Axil.vhd
+++ b/rtl/i2c/LTC2945Axil.vhd
@@ -31,7 +31,7 @@ use work.I2cPkg.all;
 
 entity LTC2945Axil is
    generic (
-      TPD_G           : time             := 1 ns);
+      TPD_G : time := 1 ns);
    port (
       -- AXI-Lite Interface
       axilClk         : in    sl;

--- a/rtl/i2c/LTC2945I2CCore.vhd
+++ b/rtl/i2c/LTC2945I2CCore.vhd
@@ -1,0 +1,433 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      LTC2945I2CCore.vhd -
+--
+--      Copyright(c) SLAC 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/4/2008 1:32:47 PM
+--      Last change: JO 3/25/2018 10:39:26 AM
+--
+----------------------------------------------------------------------------------
+-- Company:
+-- Engineer:
+--
+-- Create Date:    16:30:20 01/31/2008
+-- Design Name:
+-- Module Name:    LTC2945I2CCore - Behavioral
+-- Project Name:
+-- Target Devices:
+-- Tool versions:
+-- Description:
+--
+-- Dependencies:
+--
+-- Revision:
+-- Revision 0.01 - File Created
+-- Additional Comments:
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library IEEE;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.StdRtlPkg.all;
+use work.I2cPkg.all;
+use work.LsstI2cPkg.all;
+
+library work;
+
+entity LTC2945I2CCore is
+   generic (
+      TPD_G           : time            := 1 ns;
+      ADDR_WIDTH_G    : positive        := 16;
+      POLL_TIMEOUT_G  : positive        := 16;
+      I2C_ADDR_G      : slv(6 downto 0) := "1010000";
+      I2C_SCL_FREQ_G  : real            := 100.0E+3;  -- units of Hz
+      I2C_MIN_PULSE_G : real            := 100.0E-9;  -- units of seconds
+      AXI_CLK_FREQ_G  : real            := 156.25E+6  -- units of Hz
+
+      );
+   port (
+      Clock           : in  sl;
+      Reset           : in  sl;
+      StartRead       : in  sl;
+-- Serial interface
+      i2ci            : in  i2c_in_type;
+      i2co            : out i2c_out_type;
+-- Fifo Interface for writes
+      WrStrb          : in  sl;
+      DataIn          : in  slv(31 downto 0);
+-- Dual Port memory for output
+      RdMemAddr       : in  slv(4 downto 0);
+      MemDout         : out slv(31 downto 0);
+      -- I2C Fault
+      LTC2945ComFault : out sl
+
+      );
+end LTC2945I2CCore;
+
+architecture Behavioral of LTC2945I2CCore is
+
+   -- Note: PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
+   --       FILTER_G = (min_pulse_time / clk_period) + 1
+   constant I2C_SCL_5xFREQ_C : real    := 5.0 * I2C_SCL_FREQ_G;
+   constant PRESCALE_C       : natural := (getTimeRatio(AXI_CLK_FREQ_G, I2C_SCL_5xFREQ_C)) - 1;
+   constant FILTER_C         : natural := natural(AXI_CLK_FREQ_G * I2C_MIN_PULSE_G) + 1;
+
+   constant ADDR_SIZE_C : slv(1 downto 0) := toSlv(wordCount(ADDR_WIDTH_G, 8) - 1, 2);
+--  constant DATA_SIZE_C : slv(1 downto 0) := toSlv(wordCount(32, 8) - 1, 2);
+   constant I2C_ADDR_C  : slv(9 downto 0) := ("000" & I2C_ADDR_G);
+   constant TIMEOUT_C   : natural         := (getTimeRatio(AXI_CLK_FREQ_G, 200.0)) - 1;  -- 5 ms timeout   
+
+   constant MY_I2C_REG_MASTER_IN_INIT_C : I2cRegMasterInType := (
+      i2cAddr     => I2C_ADDR_C,
+      tenbit      => '0',
+      regAddr     => (others => '0'),
+      regWrData   => (others => '0'),
+      regOp       => '0',               -- 1 for write, 0 for read
+      regAddrSkip => '0',
+      regAddrSize => ADDR_SIZE_C,
+      regDataSize => "00",
+      regReq      => '0',
+      busReq      => '0',
+      endianness  => '1',               -- Big endian
+      repeatStart => '1'
+      );
+
+
+   type StateType is (
+      IDLE_S,
+      READ_ACK_S,
+      NEXT_REG_S,
+      FIFO_DEL_S,
+      WRITE_DATA_S,
+      WRITE_ACK_S,
+      WRITE_DONE_S
+      );
+
+   type RegType is record
+      timer      : natural range 0 to TIMEOUT_C;
+      FifoRdStrb : sl;
+      d_StartRd  : sl;
+      RamIn      : slv(31 downto 0);
+      WrdCnt     : integer range 0 to 24;  -- Current Word
+      RegAddr    : integer range 0 to 49;  -- Address in LTC
+      DelCnt     : integer range 0 to 16535;
+      StoreWrd   : sl;
+      DpRamAddr  : slv(4 downto 0);
+      byteShift  : slv(31 downto 0);
+      regIn      : I2cRegMasterInType;
+      state      : StateType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      timer      => 0,
+      FifoRdStrb => '0',
+      d_StartRd  => '0',
+      RamIn      => (others => '0'),
+      WrdCnt     => 0,
+      RegAddr    => 0,
+      DelCnt     => 0,
+      StoreWrd   => '0',
+      DpRamAddr  => (others => '0'),
+      byteShift  => (others => '0'),
+      regIn      => MY_I2C_REG_MASTER_IN_INIT_C,
+      state      => IDLE_S
+      );
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal regOut : I2cRegMasterOutType;
+
+   signal FifoDin   : slv(31 downto 0);
+   signal FifoDout  : slv(31 downto 0);
+   signal FifoEmpty : sl;
+   signal DpDout    : slv(31 downto 0);
+   signal LTCData   : slv(31 downto 0);
+
+
+   type Bytes2Read_t is array (24 downto 0) of integer range 1 to 3;
+   constant Bytes2Read : Bytes2Read_t :=
+      (
+         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1
+         );
+
+   type Addr2Write_t is array (24 downto 0) of integer range 0 to 48;
+   constant Addr2Write : Addr2Write_t :=
+      (
+--      x"30", x"2E", x"2C", x"2A", x"28", x"26", x"24", x"22", x"20", x"1E", x"1C,
+--      x"1A", x"18", x"16", x"14", x"11", x"0E", x"0B", x"08", x"05", x"04", x"03,
+--      x"02", x"01", x"00"
+         48, 46, 44, 42, 40, 38, 36, 34, 32, 30, 28,
+         26, 24, 22, 20, 17, 14, 11, 8, 5, 4, 3, 2, 1, 0
+         );
+
+begin
+
+   FifoDin         <= DataIn;
+   MemDout         <= DpDout;
+   LTC2945ComFault <= regOut.regFail;
+
+   comb : process (r, Reset, StartRead, RegOut, FifoDout, FifoEmpty, LTCData) is
+      variable v     : RegType;
+      variable WAddr : integer range 0 to 24;
+   begin
+
+      v     := r;
+      WAddr := to_integer(unsigned(FifoDout(31 downto 24)));
+
+
+-- 12 bit data is stored left justified
+--
+-- Shifting the data on writes does not seem to work, remove the shift
+--
+
+      if (WAddr < 10) then
+         LTCData <= x"00" & FifoDout(23 downto 0);
+      else
+         LTCData <= x"0000" & FifoDout(11 downto 0) & x"0";
+      end if;
+
+      v.FifoRdStrb := '0';
+      v.d_StartRd  := StartRead;
+      v.StoreWrd   := '0';
+
+      -- 12 bit data is stored left justified
+      -- 
+      if (r.wrdcnt < 10) then
+         v.RamIn := regout.regRdData(31 downto 0);
+      else
+         v.RamIn := x"00000" & regout.regRdData(15 downto 4);
+      end if;
+
+      case r.State is
+
+         when IDLE_s =>
+            v.WrdCnt                                 := 0;
+            v.RegAddr                                := 0;
+            v.regIn.regOp                            := '0';  -- Read operation
+            v.regIn.repeatStart                      := '1';
+            v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
+            v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
+            v.DpRamAddr                              := toslv(r.wrdCnt, 5);
+
+            if regOut.regAck = '0' then
+               if ((StartRead = '1') and (r.d_StartRd = '0')) then
+                  -- Send read transaction to I2cRegMaster
+                  v.regIn.regReq := '1';
+
+                  -- Next state
+                  v.state := READ_ACK_S;
+
+               elsif (FifoEmpty = '0') then
+                  -- Set the flag
+                  -- Send write transaction to I2cRegMaster
+                  v.FifoRdStrb := '1';
+
+                  -- Next state
+                  v.state := FIFO_DEL_S;
+
+               end if;
+            end if;
+
+         when Read_ACK_S =>
+            v.DpRamAddr := toslv(r.wrdCnt, 5);
+            -- Wait for completion
+            if (regOut.regAck = '1') then
+               -- Reset the flag
+               v.regIn.regReq := '0';
+               v.RegAddr      := r.RegAddr + Bytes2Read(r.WrdCnt);
+
+               v.StoreWrd := '1';
+               v.wrdCnt   := r.wrdCNt + 1;
+
+               -- Check for I2C failure
+               if (regOut.regFail = '1') then
+                  v.state := IDLE_S;
+               elsif (r.WrdCnt = 24) then
+                  v.state := IDLE_S;
+               else
+                  v.DelCnt := 5;  -- this is probably not necessary. I used it to make a gap in the scope display
+                  v.state  := NEXT_REG_S;
+               end if;
+            end if;
+
+         when NEXT_REG_S =>
+            if regOut.regAck = '0' then
+               v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
+               v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
+
+               if (R.DelCnt = 0) then
+                  v.regIn.regReq := '1';
+                  v.state        := READ_ACK_S;
+               else
+                  v.DelCnt := r.DelCnt - 1;
+               end if;
+            end if;
+
+         when FIFO_DEL_S =>
+            v.state := WRITE_DATA_S;
+
+         when WRITE_DATA_S =>
+            v.regIn.regReq                           := '1';
+            v.regIn.regOp                            := '1';  -- Write operation
+            v.regIn.repeatStart                      := '1';
+            v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(Addr2Write(WAddr), ADDR_WIDTH_G);
+            v.regIn.regDataSize                      := toslv(Bytes2Read(WAddr)-1, 2);
+
+            v.regIn.regWrData := LTCData;
+            v.state           := WRITE_ACK_S;
+
+
+         when WRITE_ACK_S =>
+
+            -- Wait for completion
+            if regOut.regAck = '1' then
+               -- Reset the flag
+               v.regIn.regReq := '0';
+               -- Check for I2C failure
+               if regOut.regFail = '1' then
+                  -- Next state
+                  v.state := IDLE_S;
+               else
+                  -- Next state
+                  v.state := WRITE_DONE_S;
+               end if;
+            end if;
+
+         when WRITE_DONE_S =>
+            if regOut.regAck = '0' then
+               -- Next state
+               v.state := IDLE_S;
+            end if;
+
+      end case;
+
+      if (Reset = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      rin <= v;
+
+   end process comb;
+
+   seq : process (Clock) is
+   begin
+      if (rising_edge(Clock)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   U_I2cRegMaster : entity work.I2cRegMaster
+      generic map(
+         TPD_G                => TPD_G,
+         OUTPUT_EN_POLARITY_G => 0,
+         FILTER_G             => FILTER_C,
+         PRESCALE_G           => PRESCALE_C
+         )
+      port map (
+         -- Clock and Reset
+         clk    => clock,
+         srst   => reset,
+         -- I2C Register Interface
+         regIn  => r.regIn,
+         regOut => regOut,
+         -- I2C Port Interface
+         i2ci   => i2ci,
+         i2co   => i2co
+         );
+
+   u_Ram : entity work.SimpleDualPortRam
+      generic map (
+         TPD_G          => 1 ns,        -- Simulated propagation delay 1 ns;
+         RST_POLARITY_G => '1',         -- '1' for active high rst, '0' for active low      
+         BRAM_EN_G      => false,
+         DOB_REG_G      => false,       -- Extra reg on doutb (folded into BRAM)
+         ALTERA_SYN_G   => false,
+         ALTERA_RAM_G   => "M9K",
+         BYTE_WR_EN_G   => false,
+         DATA_WIDTH_G   => 32,
+         BYTE_WIDTH_G   => 8,           -- If BRAM, should be multiple or 8 or 9
+         ADDR_WIDTH_G   => 5,
+         INIT_G         => "0"
+         )
+      port map (
+         -- Port A     
+         clka    => Clock,
+         ena     => '1',
+         wea     => r.StoreWrd,
+         weaByte => "1111",
+         addra   => r.DpRamAddr,
+         dina    => r.ramin,
+         -- Port
+         clkb    => Clock,
+         enb     => '1',
+         rstb    => Reset,
+         addrb   => RdMemAddr(4 downto 0),
+         doutb   => DpDout
+         );
+
+   u_Fifo : entity work.Fifo
+      generic map (
+         TPD_G           => 1 ns,
+         RST_POLARITY_G  => '1',        -- '1' for active high rst, '0' for active low
+         RST_ASYNC_G     => false,
+         GEN_SYNC_FIFO_G => true,
+         BRAM_EN_G       => true,
+         FWFT_EN_G       => false,
+         USE_DSP48_G     => "no",
+         ALTERA_SYN_G    => false,
+         ALTERA_RAM_G    => "M9K",
+         USE_BUILT_IN_G  => false,  --if set to true, this module is only xilinx compatible only!!!
+         XIL_DEVICE_G    => "7SERIES",  --xilinx only generic parameter    
+         SYNC_STAGES_G   => 3,
+         PIPE_STAGES_G   => 0,
+         DATA_WIDTH_G    => 32,
+         ADDR_WIDTH_G    => 5,
+         INIT_G          => "0",
+         FULL_THRES_G    => 1,
+         EMPTY_THRES_G   => 1
+         )
+      port map (
+         -- Resets
+         rst    => Reset,
+         --Write Ports (wr_clk domain)
+         wr_clk => Clock,
+         wr_en  => WrStrb,
+         din    => FifoDin,
+--      wr_data_count => open,
+--      wr_ack        => open,
+--      overflow      => open,
+--      prog_full     => open,
+--      almost_full   => open,
+--      full          => open,
+--      not_full      => open,
+         --Read Ports (rd_clk domain)
+         rd_clk => '0',                 --unused if GEN_SYNC_FIFO_G = true
+         rd_en  => r.FifoRdStrb,
+         dout   => FifoDout,
+--      rd_data_count => open,
+--      valid         => open,
+--      underflow     => open,
+--      prog_empty    => open,
+--      almost_empty => open,
+         empty  => FifoEmpty
+         );
+
+
+
+end Behavioral;
+

--- a/rtl/i2c/LTC2945I2CCore.vhd
+++ b/rtl/i2c/LTC2945I2CCore.vhd
@@ -46,8 +46,6 @@ use work.StdRtlPkg.all;
 use work.I2cPkg.all;
 use work.LsstI2cPkg.all;
 
-library work;
-
 entity LTC2945I2CCore is
    generic (
       TPD_G           : time            := 1 ns;
@@ -63,13 +61,13 @@ entity LTC2945I2CCore is
       Clock           : in  sl;
       Reset           : in  sl;
       StartRead       : in  sl;
--- Serial interface
+      -- Serial interface
       i2ci            : in  i2c_in_type;
       i2co            : out i2c_out_type;
--- Fifo Interface for writes
+      -- Fifo Interface for writes
       WrStrb          : in  sl;
       DataIn          : in  slv(31 downto 0);
--- Dual Port memory for output
+      -- Dual Port memory for output
       RdMemAddr       : in  slv(4 downto 0);
       MemDout         : out slv(31 downto 0);
       -- I2C Fault

--- a/rtl/i2c/LTC2945_Tb.vhd
+++ b/rtl/i2c/LTC2945_Tb.vhd
@@ -50,74 +50,72 @@ use unisim.vcomponents.all;
 use work.StdRtlPkg.all;
 use work.I2cPkg.all;
 
-library work;
-
 entity LTC2945_Tb is
-  port (
-    Clk : in sl;
-  rst          : in    sl;
-  ADCReadStart : in    sl;
-  sda        : inout sl;
-  scl      : inout sl;
+   port (
+      Clk          : in    sl;
+      rst          : in    sl;
+      ADCReadStart : in    sl;
+      sda          : inout sl;
+      scl          : inout sl;
 
-  fifowr       : in    sl;
-  fifodatain   : in    slv(31 downto 0);
-  RdMemAddr    : in    slv(4 downto 0);
-  DpMemDataOut      : out   slv(31 downto 0)
-    );
+      fifowr       : in  sl;
+      fifodatain   : in  slv(31 downto 0);
+      RdMemAddr    : in  slv(4 downto 0);
+      DpMemDataOut : out slv(31 downto 0)
+      );
 
 
 end LTC2945_Tb;
 
 architecture Behavioral of LTC2945_Tb is
 
-signal i2ci : i2c_in_type;
-signal i2co : i2c_out_type;
+   signal i2ci : i2c_in_type;
+   signal i2co : i2c_out_type;
 
 begin
 
-scl <= 'H';
-SDA <= 'H';
+   scl <= 'H';
+   SDA <= 'H';
 
 
-      IOBUF_SCL : IOBUF
-         port map (
-            O  => i2ci.scl,       -- Buffer output
-            IO => scl,  -- buffer inout port (connect directly to top-level port)
-            I  => i2co.scl,       -- Buffer input
-            T  => i2co.scloen
-            );             -- 3-state enable input, high=input, low=output  
+   IOBUF_SCL : IOBUF
+      port map (
+         O  => i2ci.scl,                -- Buffer output
+         IO => scl,                     -- buffer inout port (connect directly to top-level port)
+         I  => i2co.scl,                -- Buffer input
+         T  => i2co.scloen
+         );                             -- 3-state enable input, high=input, low=output  
 
-      IOBUF_SDA : IOBUF               -- output buffer to ltc
-         port map (                     -- Buffer output
-         O  => i2ci.sda,       -- Buffer output
-         IO => sda,  -- buffer inout port (connect directly to top-level port)
-         I  => i2co.sda,       -- Buffer input
+   IOBUF_SDA : IOBUF                    -- output buffer to ltc
+      port map (                        -- Buffer output
+         O  => i2ci.sda,                -- Buffer output
+         IO => sda,                     -- buffer inout port (connect directly to top-level port)
+         I  => i2co.sda,                -- Buffer input
          T  => i2co.sdaoen
-         );  
+         );
 
-  u_LTC2945 : entity work.LTC2945i2cCore
-    generic map (
-      TPD_G           => 1 ns,
-      ADDR_WIDTH_G    => 8,
-      POLL_TIMEOUT_G  => 16,
-      I2C_ADDR_G      => "1101111",     -- LTC Addr1, Addr0 = "00"
-      I2C_SCL_FREQ_G  => 100.0E+3,      -- units of Hz
-      I2C_MIN_PULSE_G => 100.0E-9       -- units of seconds
-      )
-    port map (
-      Clock     => Clk,
-      Reset     => rst,
-      StartRead => ADCReadStart,
-      -- Serial interface
-      i2ci      => i2ci,
-      i2co      => i2co,
-      -- Fifo Interface for writes
-      WrStrb    => FifoWr,
-      DataIn    => FifoDataIn,
-      -- Dual Port memory for output
-      RdMemAddr => RdMemAddr,
-      MemDout   => DpMemDataOut
-      );
+   u_LTC2945 : entity work.LTC2945i2cCore
+      generic map (
+         TPD_G           => 1 ns,
+         ADDR_WIDTH_G    => 8,
+         POLL_TIMEOUT_G  => 16,
+         I2C_ADDR_G      => "1101111",  -- LTC Addr1, Addr0 = "00"
+         I2C_SCL_FREQ_G  => 100.0E+3,   -- units of Hz
+         I2C_MIN_PULSE_G => 100.0E-9    -- units of seconds
+         )
+      port map (
+         Clock     => Clk,
+         Reset     => rst,
+         StartRead => ADCReadStart,
+         -- Serial interface
+         i2ci      => i2ci,
+         i2co      => i2co,
+         -- Fifo Interface for writes
+         WrStrb    => FifoWr,
+         DataIn    => FifoDataIn,
+         -- Dual Port memory for output
+         RdMemAddr => RdMemAddr,
+         MemDout   => DpMemDataOut
+         );
 end Behavioral;
 

--- a/rtl/i2c/LTC2945_Tb.vhd
+++ b/rtl/i2c/LTC2945_Tb.vhd
@@ -1,0 +1,123 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      .vhd -
+--
+--      Copyright(c) SLAC 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/4/2008 1:32:47 PM
+--      Last change: JO 3/6/2018 8:51:53 AM
+--
+----------------------------------------------------------------------------------
+-- Company:
+-- Engineer:
+--
+-- Create Date:    16:30:20 01/31/2008
+-- Design Name:
+-- Module Name:    LTC2945_Tb - Behavioral
+-- Project Name:
+-- Target Devices:
+-- Tool versions:
+-- Description:
+--
+-- Dependencies:
+--
+-- Revision:
+-- Revision 0.01 - File Created
+-- Additional Comments:
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.all;
+use IEEE.STD_LOGIC_ARITH.all;
+use IEEE.STD_LOGIC_UNSIGNED.all;
+
+
+library unisim;
+use unisim.vcomponents.all;
+
+use work.StdRtlPkg.all;
+use work.I2cPkg.all;
+
+library work;
+
+entity LTC2945_Tb is
+  port (
+    Clk : in sl;
+  rst          : in    sl;
+  ADCReadStart : in    sl;
+  sda        : inout sl;
+  scl      : inout sl;
+
+  fifowr       : in    sl;
+  fifodatain   : in    slv(31 downto 0);
+  RdMemAddr    : in    slv(4 downto 0);
+  DpMemDataOut      : out   slv(31 downto 0)
+    );
+
+
+end LTC2945_Tb;
+
+architecture Behavioral of LTC2945_Tb is
+
+signal i2ci : i2c_in_type;
+signal i2co : i2c_out_type;
+
+begin
+
+scl <= 'H';
+SDA <= 'H';
+
+
+      IOBUF_SCL : IOBUF
+         port map (
+            O  => i2ci.scl,       -- Buffer output
+            IO => scl,  -- buffer inout port (connect directly to top-level port)
+            I  => i2co.scl,       -- Buffer input
+            T  => i2co.scloen
+            );             -- 3-state enable input, high=input, low=output  
+
+      IOBUF_SDA : IOBUF               -- output buffer to ltc
+         port map (                     -- Buffer output
+         O  => i2ci.sda,       -- Buffer output
+         IO => sda,  -- buffer inout port (connect directly to top-level port)
+         I  => i2co.sda,       -- Buffer input
+         T  => i2co.sdaoen
+         );  
+
+  u_LTC2945 : entity work.LTC2945i2cCore
+    generic map (
+      TPD_G           => 1 ns,
+      ADDR_WIDTH_G    => 8,
+      POLL_TIMEOUT_G  => 16,
+      I2C_ADDR_G      => "1101111",     -- LTC Addr1, Addr0 = "00"
+      I2C_SCL_FREQ_G  => 100.0E+3,      -- units of Hz
+      I2C_MIN_PULSE_G => 100.0E-9       -- units of seconds
+      )
+    port map (
+      Clock     => Clk,
+      Reset     => rst,
+      StartRead => ADCReadStart,
+      -- Serial interface
+      i2ci      => i2ci,
+      i2co      => i2co,
+      -- Fifo Interface for writes
+      WrStrb    => FifoWr,
+      DataIn    => FifoDataIn,
+      -- Dual Port memory for output
+      RdMemAddr => RdMemAddr,
+      MemDout   => DpMemDataOut
+      );
+end Behavioral;
+

--- a/rtl/i2c/LambdaAxil.vhd
+++ b/rtl/i2c/LambdaAxil.vhd
@@ -1,0 +1,171 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      LambdaAxil.vhd - 
+--
+--      Copyright(c) SLAC National Accelerator Laboratory 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/14/2018 8:56:03 AM
+--      Last change: JO 3/20/2018 11:37:33 AM
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+
+use work.StdRtlPkg.all;
+use work.AxiStreamPkg.all;
+use work.AxiLitePkg.all;
+use work.I2cPkg.all;
+
+entity LambdaAxil is
+   generic (
+      TPD_G : time := 1 ns);
+   port (
+      -- AXI-Lite Interface
+      axilClk         : in    sl;
+      axilRst         : in    sl;
+      axilReadMaster  : in    AxiLiteReadMasterType;
+      axilReadSlave   : out   AxiLiteReadSlaveType;
+      axilWriteMaster : in    AxiLiteWriteMasterType;
+      axilWriteSlave  : out   AxiLiteWriteSlaveType;
+      -- I2C bus
+      i2ci            : inout i2c_in_type;
+      i2co            : inout i2c_out_type;
+      -- Start Conversion
+      StartConv       : in    sl;
+      -- I2C Fault
+      LambdaComFault  : out   sl
+      );
+end entity LambdaAxil;
+
+architecture Behavioral of LambdaAxil is
+
+   type RegType is record
+      ADCReadStart   : sl;
+      FifoWr         : sl;
+      RdDelay        : sl;
+      axilReadSlave  : AxiLiteReadSlaveType;
+      axilWriteSlave : AxiLiteWriteSlaveType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      ADCReadStart   => '0',
+      FifoWr         => '0',
+      RdDelay        => '0',
+      axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+      axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
+
+   signal r          : RegType := REG_INIT_C;
+   signal rin        : RegType;
+   signal FifoDataIn : slv(31 downto 0);
+   signal LTCDataOut : slv(31 downto 0);
+   signal Convert    : sl;
+
+begin
+
+   comb : process (LTCDataOut, axilReadMaster, axilRst, axilWriteMaster, r) is
+      variable v          : RegType;
+      variable axilStatus : AxiLiteStatusType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Reset the strobes
+      v.ADCReadStart := '0';
+      v.FifoWr       := '0';
+      v.RdDelay      := '0';
+
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
+
+      -- Check for a write request
+      if (axilStatus.writeEnable = '1') then
+         -- Check for start
+         if (axilWriteMaster.awaddr(11 downto 0) = x"100") then
+            v.ADCReadStart := '1';
+         elsif (axilWriteMaster.awaddr(11 downto 0) < x"100") then
+            v.FifoWr := '1';
+         end if;
+         -- Send AXI-Lite Response
+         axiSlaveWriteResponse(v.axilWriteSlave, AXI_RESP_OK_C);
+      end if;
+
+      -- Check for a read request
+      if (axilStatus.readEnable = '1') then
+         -- Wait 1 cycle for data to get out of the DPMEM pipeline
+         v.RdDelay := '1';
+      end if;
+
+      if (r.RdDelay = '1') then
+         -- Forward the read data from the RAM
+         v.axilReadSlave.rdata := LTCDataOut;
+         -- Send AXI-Lite Response
+         axiSlaveReadResponse(v.axilReadSlave, AXI_RESP_OK_C);
+      end if;
+
+      -- Reset
+      if (axilRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+      -- Outputs 
+      axilReadSlave  <= r.axilReadSlave;
+      axilWriteSlave <= r.axilWriteSlave;
+
+      -- Fifo Data is the address and 24 bit data to the ADC which
+      -- becomes the ADC register and 24 bit data to write
+      FifoDataIn <= axilWriteMaster.awaddr(9 downto 2) & axilWriteMaster.wdata(23 downto 0);
+
+   end process;
+
+   seq : process (axilClk) is
+   begin
+      if (rising_edge(axilClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+
+
+   u_Lambda : entity work.LambdaI2CCore
+      generic map (
+         TPD_G           => 1 ns,
+         ADDR_WIDTH_G    => 8,
+         POLL_TIMEOUT_G  => 16,
+         I2C_ADDR_G      => "1010000",  -- Lambda Addr2, Addr1, Addr0 = "000", A0
+         I2C_SCL_FREQ_G  => 100.0E+3,   -- units of Hz
+         I2C_MIN_PULSE_G => 100.0E-9    -- units of seconds
+         )
+      port map (
+         Clock     => axilClk,
+         Reset     => axilRst,
+--      StartRead => r.ADCReadStart,
+         StartRead => StartConv,
+         -- Serial interface
+         i2ci      => i2ci,
+         i2co      => i2co,
+         -- Fifo Interface for writes
+         WrStrb    => r.FifoWr,
+         DataIn    => FifoDataIn,
+         -- Dual Port memory for output
+         RdMemAddr => axilReadMaster.araddr(6 downto 2),
+         MemDout   => LTCDataOut
+         );
+
+end;
+

--- a/rtl/i2c/LambdaI2CCore.vhd
+++ b/rtl/i2c/LambdaI2CCore.vhd
@@ -1,0 +1,375 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      LambdaI2CCore.vhd -
+--
+--      Copyright(c) SLAC 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/4/2008 1:32:47 PM
+--      Last change: JO 3/20/2018 10:59:44 AM
+--
+----------------------------------------------------------------------------------
+-- Company:
+-- Engineer:
+--
+-- Create Date:    16:30:20 01/31/2008
+-- Design Name:
+-- Module Name:    LambdaI2CCore - Behavioral
+-- Project Name:
+-- Target Devices:
+-- Tool versions:
+-- Description:
+--
+-- Dependencies:
+--
+-- Revision:
+-- Revision 0.01 - File Created
+-- Additional Comments:
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.all;
+use IEEE.STD_LOGIC_ARITH.all;
+use IEEE.STD_LOGIC_UNSIGNED.all;
+
+
+use work.StdRtlPkg.all;
+use work.I2cPkg.all;
+use work.LsstI2cPkg.all;
+
+library work;
+
+entity LambdaI2CCore is
+   generic (
+      TPD_G           : time            := 1 ns;
+      ADDR_WIDTH_G    : positive        := 16;
+      POLL_TIMEOUT_G  : positive        := 16;
+      I2C_ADDR_G      : slv(6 downto 0) := "1010000";
+      I2C_SCL_FREQ_G  : real            := 100.0E+3;  -- units of Hz
+      I2C_MIN_PULSE_G : real            := 100.0E-9;  -- units of seconds
+      AXI_CLK_FREQ_G  : real            := 156.25E+6  -- units of Hz
+
+      );
+   port (
+      Clock          : in  sl;
+      Reset          : in  sl;
+      StartRead      : in  sl;
+-- Serial interface
+      i2ci           : in  i2c_in_type;
+      i2co           : out i2c_out_type;
+-- Fifo Interface for writes
+      WrStrb         : in  sl;
+      DataIn         : in  slv(31 downto 0);
+-- Dual Port memory for output
+      RdMemAddr      : in  slv(4 downto 0);
+      MemDout        : out slv(31 downto 0);
+      -- I2C Fault
+      LambdaComFault : out sl
+
+      );
+end LambdaI2CCore;
+
+architecture Behavioral of LambdaI2CCore is
+
+   -- Note: PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
+   --       FILTER_G = (min_pulse_time / clk_period) + 1
+   constant I2C_SCL_5xFREQ_C : real    := 5.0 * I2C_SCL_FREQ_G;
+   constant PRESCALE_C       : natural := (getTimeRatio(AXI_CLK_FREQ_G, I2C_SCL_5xFREQ_C)) - 1;
+   constant FILTER_C         : natural := natural(AXI_CLK_FREQ_G * I2C_MIN_PULSE_G) + 1;
+
+   constant ADDR_SIZE_C : slv(1 downto 0) := toSlv(wordCount(ADDR_WIDTH_G, 8) - 1, 2);
+--  constant DATA_SIZE_C : slv(1 downto 0) := toSlv(wordCount(32, 8) - 1, 2);
+   constant I2C_ADDR_C  : slv(9 downto 0) := ("000" & I2C_ADDR_G);
+   constant TIMEOUT_C   : natural         := (getTimeRatio(AXI_CLK_FREQ_G, 200.0)) - 1;  -- 5 ms timeout   
+
+   constant MY_I2C_BYTE_MASTER_IN_INIT_C : I2cByteMasterInType := (
+      i2cAddr     => I2C_ADDR_C,
+      tenbit      => '0',
+      regAddr     => (others => '0'),
+      regWrData   => (others => '0'),
+      regOp       => '0',               -- 1 for write, 0 for read
+      regAddrSkip => '0',
+      regAddrSize => ADDR_SIZE_C,
+      regDataSize => x"00",
+      regReq      => '0',
+      busReq      => '0',
+      endianness  => '1',               -- Big endian
+      repeatStart => '1'
+      );
+
+
+   type StateType is (
+      IDLE_S,
+      READ_ACK_S,
+      NEXT_BYTE_S
+      );
+
+   type RegType is record
+      timer     : natural range 0 to TIMEOUT_C;
+      RnW       : sl;
+      StartDel  : sl;
+      DelAck    : sl;
+      WrdCnt    : integer range 0 to 24;  -- Current Word
+      RegAddr   : integer range 0 to 49;  -- Address in LTC
+      DelCnt    : integer range 0 to 16384;
+      StoreWrd  : sl;
+      DpRamAddr : slv(4 downto 0);
+      byteShift : slv(31 downto 0);
+      byteCnt   : slv(1 downto 0);        -- Wrap every 4 bytes to store 32bit values
+      regIn     : I2cByteMasterInType;
+      state     : StateType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      timer     => 0,
+      RnW       => '0',
+      DelAck    => '0',
+      StartDel  => '0',
+      WrdCnt    => 0,
+      RegAddr   => 0,
+      DelCnt    => 0,
+      StoreWrd  => '0',
+      DpRamAddr => (others => '0'),
+      byteShift => (others => '0'),
+      byteCnt   => "00",
+      regIn     => MY_I2C_BYTE_MASTER_IN_INIT_C,
+      state     => IDLE_S
+      );
+
+   signal r         : RegType := REG_INIT_C;
+   signal rin       : RegType;
+   signal regOut    : I2cByteMasterOutType;
+   signal FifoDin   : slv(31 downto 0);
+   signal FifoDout  : slv(31 downto 0);
+   signal FifoEmpty : sl;
+   signal DpDout    : slv(31 downto 0);
+   signal LTCData   : slv(31 downto 0);
+   signal RamIn     : slv(31 downto 0);
+
+   type Bytes2Read_t is array (9 downto 0) of integer range 1 to 20;
+   constant Bytes2Read : Bytes2Read_t :=
+      (
+         3, 8, 12, 1, 2, 2, 2, 4, 4, 20
+         );
+
+begin
+
+   FifoDin        <= DataIn;
+   MemDout        <= DpDout;
+   LambdaComFault <= regOut.regFail;
+
+   comb : process (r, Reset, StartRead, RegOut) is
+      variable v : RegType;
+   begin
+      v := r;
+
+      v.StoreWrd  := '0';
+      v.DpRamAddr := conv_std_logic_vector(r.wrdCnt, 5);
+      v.DelAck    := regOut.regAck;
+
+      if (regout.regRdDav = '1') then
+         v.byteShift(31 downto 0) := r.byteShift(23 downto 0) & regout.regRdData;
+         if (r.byteCnt = "11") then
+            v.WrdCnt   := r.WrdCnt + 1;
+            v.StoreWrd := '1';
+            v.byteCnt  := "00";
+         else
+            v.byteCnt := r.byteCnt + 1;
+         end if;
+      elsif (r.DelAck = '1') then
+         v.byteShift := (others => '0');
+         v.byteCnt   := "00";
+      end if;
+
+      case r.State is
+         when IDLE_s =>
+            v.WrdCnt  := 0;
+            v.RegAddr := 1;             -- Lambda supply does not have a register 0
+            -- Set the flag
+            v.RnW     := '0';
+
+            if regOut.regAck = '0' then
+               if (StartRead = '1') then
+                  -- Send read transaction to I2cRegMaster
+                  v.regIn.regReq                           := '1';
+                  v.regIn.regOp                            := '0';
+                  v.regIn.repeatStart                      := '1';
+                  v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := conv_std_logic_vector(r.RegAddr, ADDR_WIDTH_G);
+                  v.regIn.regDataSize                      := conv_std_logic_vector(Bytes2Read(r.RegAddr-1)-1, 8);
+                  -- v.regIn.regDataSize                      := "00";
+
+                  -- Next state
+                  v.state := READ_ACK_S;
+
+               end if;
+            end if;
+
+         when Read_ACK_S =>
+            -- Wait for completion
+            if (regOut.regAck = '1') then
+               -- Reset the flag
+               v.regIn.regReq := '0';
+               v.StoreWrd     := '1';
+-- Lambda reads many bytes from 1 address!
+-- Only increment the address by 1
+--          v.RegAddr      := r.RegAddr + Bytes2Read(r.WrdCnt);
+               v.RegAddr      := r.RegAddr + 1;
+               v.WrdCnt       := r.WrdCnt + 1;
+
+-- if r.RnW = '0' then
+               -- Currenty no write operation
+
+               -- read operation
+               --
+               -- Check for I2C failure
+               if (regOut.regFail = '1') then
+                  v.state := IDLE_S;
+               elsif (r.RegAddr = 9) then
+                  v.state := IDLE_S;
+               else
+                  v.DelCnt := 5;
+                  v.state  := NEXT_BYTE_S;
+               end if;
+            end if;
+
+         when NEXT_BYTE_S =>
+            --       if regOut.regAck = '0' then
+            v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := conv_std_logic_vector(r.RegAddr, ADDR_WIDTH_G);
+            v.regIn.regDataSize                      := conv_std_logic_vector(Bytes2Read(r.RegAddr-1)-1, 8);
+
+            if (R.DelCnt = 0) then
+               v.regIn.regReq := '1';
+               v.state        := READ_ACK_S;
+            else
+               v.DelCnt := r.DelCnt - 1;
+            end if;
+      --       end if;
+      end case;
+
+      if (Reset = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      rin <= v;
+
+   end process comb;
+
+   seq : process (Clock) is
+   begin
+      if (rising_edge(Clock)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   U_I2cByteMaster : entity work.I2cByteMaster
+      generic map(
+         TPD_G                => TPD_G,
+         OUTPUT_EN_POLARITY_G => 0,
+         FILTER_G             => FILTER_C,
+         PRESCALE_G           => PRESCALE_C
+         )
+      port map (
+         -- Clock and Reset
+         clk    => clock,
+         srst   => reset,
+         -- I2C Register Interface
+         regIn  => r.regIn,
+         regOut => regOut,
+         -- I2C Port Interface
+         i2ci   => i2ci,
+         i2co   => i2co
+
+         );
+
+   u_Ram : entity work.SimpleDualPortRam
+      generic map (
+         TPD_G          => 1 ns,        -- Simulated propagation delay 1 ns;
+         RST_POLARITY_G => '1',         -- '1' for active high rst, '0' for active low      
+         BRAM_EN_G      => false,
+         DOB_REG_G      => false,       -- Extra reg on doutb (folded into BRAM)
+         ALTERA_SYN_G   => false,
+         ALTERA_RAM_G   => "M9K",
+         BYTE_WR_EN_G   => false,
+         DATA_WIDTH_G   => 32,
+         BYTE_WIDTH_G   => 8,           -- If BRAM, should be multiple or 8 or 9
+         ADDR_WIDTH_G   => 5,
+         INIT_G         => "0"
+         )
+      port map (
+         -- Port A     
+         clka    => Clock,
+         ena     => '1',
+         wea     => r.StoreWrd,
+         weaByte => "1111",
+         addra   => r.DpRamAddr,
+         dina    => r.byteShift,
+         -- Port
+         clkb    => Clock,
+         enb     => '1',
+         rstb    => Reset,
+         addrb   => RdMemAddr(4 downto 0),
+         doutb   => DpDout
+         );
+
+   u_Fifo : entity work.Fifo
+      generic map (
+         TPD_G           => 1 ns,
+         RST_POLARITY_G  => '1',        -- '1' for active high rst, '0' for active low
+         RST_ASYNC_G     => false,
+         GEN_SYNC_FIFO_G => true,
+         BRAM_EN_G       => true,
+         FWFT_EN_G       => false,
+         USE_DSP48_G     => "no",
+         ALTERA_SYN_G    => false,
+         ALTERA_RAM_G    => "M9K",
+         USE_BUILT_IN_G  => false,  --if set to true, this module is only xilinx compatible only!!!
+         XIL_DEVICE_G    => "7SERIES",  --xilinx only generic parameter    
+         SYNC_STAGES_G   => 3,
+         PIPE_STAGES_G   => 0,
+         DATA_WIDTH_G    => 32,
+         ADDR_WIDTH_G    => 5,
+         INIT_G          => "0",
+         FULL_THRES_G    => 1,
+         EMPTY_THRES_G   => 1
+         )
+      port map (
+         -- Resets
+         rst    => Reset,
+         --Write Ports (wr_clk domain)
+         wr_clk => Clock,
+         wr_en  => WrStrb,
+         din    => FifoDin,
+--      wr_data_count => open,
+         --     wr_ack       => open,
+--      overflow      => open,
+--      prog_full    => open,
+--      almost_full   => open,
+--      full          => open,
+--      not_full      => open,
+         --Read Ports (rd_clk domain)
+         rd_clk => '0',                 --unused if GEN_SYNC_FIFO_G = true
+         rd_en  => '1',
+         dout   => FifoDout,
+--      rd_data_count => open,
+--      valid         => open,
+--      underflow     => open,
+--      prog_empty    => open,
+--      almost_empty => open,
+         empty  => FifoEmpty
+         );
+
+
+
+end Behavioral;
+

--- a/rtl/i2c/LsstI2cPkg.vhd
+++ b/rtl/i2c/LsstI2cPkg.vhd
@@ -1,0 +1,74 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      LsstDcPduPkg.vhd -
+--
+--      Copyright(c) SLAC National Accelerator Laboratory 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/14/2018 12:23:56 PM
+--      Last change: JO 3/15/2018 2:11:35 PM
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library work;
+use work.I2cPkg.all;
+use work.StdRtlPkg.all;
+
+package LsstI2cPkg is
+
+   constant SYS_CLK_FREQ_C : real := 125.0E+6;
+   type Lsst5VDcPdu_i2c_in is array (19 downto 0) of i2c_in_type;
+   type Lsst5VDcPdu_i2c_out is array (19 downto 0) of i2c_out_type;
+
+   type Lsst24VDcPdu_i2c_in is array (11 downto 0) of i2c_in_type;
+   type Lsst24VDcPdu_i2c_out is array (11 downto 0) of i2c_out_type;
+
+   type jjo_I2cRegMasterInType is record
+      i2cAddr     : slv(9 downto 0);
+      tenbit      : sl;
+      regAddr     : slv(31 downto 0);
+      regWrData   : slv(31 downto 0);
+      regOp       : sl;
+      regAddrSkip : sl;
+      regAddrSize : slv(1 downto 0);
+      regDataSize : slv(7 downto 0);
+      regReq      : sl;
+      busReq      : sl;
+      endianness  : sl;
+      repeatStart : sl;
+   end record;
+
+   type I2cByteMasterOutType is record
+      regAck      : sl;                 -- Last byte data is available
+      regFail     : sl;
+      regFailCode : slv(7 downto 0);
+      regRdData   : slv(7 downto 0);    -- Byte data
+      regRdDav    : sl;                 -- New byte data is available
+   end record;
+
+   type I2cByteMasterInType is record   -- same as I2CRegMasterInType, datasize is 8 not 2
+      i2cAddr     : slv(9 downto 0);
+      tenbit      : sl;
+      regAddr     : slv(31 downto 0);
+      regWrData   : slv(31 downto 0);
+      regOp       : sl;
+      regAddrSkip : sl;
+      regAddrSize : slv(1 downto 0);
+      regDataSize : slv(7 downto 0);
+      regReq      : sl;
+      busReq      : sl;
+      endianness  : sl;
+      repeatStart : sl;
+   end record;
+
+end LsstI2cPkg;

--- a/rtl/i2c/LsstI2cPkg.vhd
+++ b/rtl/i2c/LsstI2cPkg.vhd
@@ -26,27 +26,27 @@ use work.StdRtlPkg.all;
 
 package LsstI2cPkg is
 
-   constant SYS_CLK_FREQ_C : real := 125.0E+6;
-   type Lsst5VDcPdu_i2c_in is array (19 downto 0) of i2c_in_type;
-   type Lsst5VDcPdu_i2c_out is array (19 downto 0) of i2c_out_type;
+--    constant SYS_CLK_FREQ_C : real := 125.0E+6;
+--    type Lsst5VDcPdu_i2c_in is array (19 downto 0) of i2c_in_type;
+--    type Lsst5VDcPdu_i2c_out is array (19 downto 0) of i2c_out_type;
 
-   type Lsst24VDcPdu_i2c_in is array (11 downto 0) of i2c_in_type;
-   type Lsst24VDcPdu_i2c_out is array (11 downto 0) of i2c_out_type;
+--    type Lsst24VDcPdu_i2c_in is array (11 downto 0) of i2c_in_type;
+--    type Lsst24VDcPdu_i2c_out is array (11 downto 0) of i2c_out_type;
 
-   type jjo_I2cRegMasterInType is record
-      i2cAddr     : slv(9 downto 0);
-      tenbit      : sl;
-      regAddr     : slv(31 downto 0);
-      regWrData   : slv(31 downto 0);
-      regOp       : sl;
-      regAddrSkip : sl;
-      regAddrSize : slv(1 downto 0);
-      regDataSize : slv(7 downto 0);
-      regReq      : sl;
-      busReq      : sl;
-      endianness  : sl;
-      repeatStart : sl;
-   end record;
+--    type jjo_I2cRegMasterInType is record
+--       i2cAddr     : slv(9 downto 0);
+--       tenbit      : sl;
+--       regAddr     : slv(31 downto 0);
+--       regWrData   : slv(31 downto 0);
+--       regOp       : sl;
+--       regAddrSkip : sl;
+--       regAddrSize : slv(1 downto 0);
+--       regDataSize : slv(7 downto 0);
+--       regReq      : sl;
+--       busReq      : sl;
+--       endianness  : sl;
+--       repeatStart : sl;
+--    end record;
 
    type I2cByteMasterOutType is record
       regAck      : sl;                 -- Last byte data is available

--- a/rtl/i2c/SA56004Axil.vhd
+++ b/rtl/i2c/SA56004Axil.vhd
@@ -30,144 +30,144 @@ use work.AxiLitePkg.all;
 use work.I2cPkg.all;
 
 entity SA56004Axil is
-  generic (
-    TPD_G            : time             := 1 ns;
-    AXI_BASE_ADDR_G  : slv(31 downto 0) := x"00000000";
-    AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C
-    );
-  port (
-    -- AXI-Lite Interface
-    axilClk         : in    sl;
-    axilRst         : in    sl;
-    axilReadMaster  : in    AxiLiteReadMasterType;
-    axilReadSlave   : out   AxiLiteReadSlaveType;
-    axilWriteMaster : in    AxiLiteWriteMasterType;
-    axilWriteSlave  : out   AxiLiteWriteSlaveType;
-    -- I2C bus
-    i2ci            : inout i2c_in_type;
-    i2co            : inout i2c_out_type;
-    -- Start Conversion
-    StartConv       : in    sl;
-    -- I2C fault
-    SA56004ComFault : out   sl
-    );
+   generic (
+      TPD_G            : time             := 1 ns;
+      AXI_BASE_ADDR_G  : slv(31 downto 0) := x"00000000";
+      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C
+      );
+   port (
+      -- AXI-Lite Interface
+      axilClk         : in    sl;
+      axilRst         : in    sl;
+      axilReadMaster  : in    AxiLiteReadMasterType;
+      axilReadSlave   : out   AxiLiteReadSlaveType;
+      axilWriteMaster : in    AxiLiteWriteMasterType;
+      axilWriteSlave  : out   AxiLiteWriteSlaveType;
+      -- I2C bus
+      i2ci            : inout i2c_in_type;
+      i2co            : inout i2c_out_type;
+      -- Start Conversion
+      StartConv       : in    sl;
+      -- I2C fault
+      SA56004ComFault : out   sl
+      );
 end entity SA56004Axil;
 
 architecture Behavioral of SA56004Axil is
 
-  type RegType is record
-    ADCReadStart   : sl;
-    FifoWr         : sl;
-    RdDelay        : sl;
-    axilReadSlave  : AxiLiteReadSlaveType;
-    axilWriteSlave : AxiLiteWriteSlaveType;
-  end record;
+   type RegType is record
+      ADCReadStart   : sl;
+      FifoWr         : sl;
+      RdDelay        : sl;
+      axilReadSlave  : AxiLiteReadSlaveType;
+      axilWriteSlave : AxiLiteWriteSlaveType;
+   end record;
 
-  constant REG_INIT_C : RegType := (
-    ADCReadStart   => '0',
-    FifoWr         => '0',
-    RdDelay        => '0',
-    axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
-    axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
+   constant REG_INIT_C : RegType := (
+      ADCReadStart   => '0',
+      FifoWr         => '0',
+      RdDelay        => '0',
+      axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+      axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
 
-  signal r          : RegType := REG_INIT_C;
-  signal rin        : RegType;
-  signal FifoDataIn : slv(31 downto 0);
-  signal LTCDataOut : slv(31 downto 0);
-  signal Convert    : sl;
+   signal r          : RegType := REG_INIT_C;
+   signal rin        : RegType;
+   signal FifoDataIn : slv(31 downto 0);
+   signal LTCDataOut : slv(31 downto 0);
+   signal Convert    : sl;
 
 begin
 
-  comb : process (LTCDataOut, axilReadMaster, axilRst, axilWriteMaster, r) is
-    variable v          : RegType;
-    variable axilStatus : AxiLiteStatusType;
-  begin
-    -- Latch the current value
-    v := r;
+   comb : process (LTCDataOut, axilReadMaster, axilRst, axilWriteMaster, r) is
+      variable v          : RegType;
+      variable axilStatus : AxiLiteStatusType;
+   begin
+      -- Latch the current value
+      v := r;
 
-    -- Reset the strobes
-    v.ADCReadStart := '0';
-    v.FifoWr       := '0';
-    v.RdDelay      := '0';
+      -- Reset the strobes
+      v.ADCReadStart := '0';
+      v.FifoWr       := '0';
+      v.RdDelay      := '0';
 
-    -- Determine the transaction type
-    axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
 
-    -- Check for a write request
-    if (axilStatus.writeEnable = '1') then
-      -- Check for start
-      if (axilWriteMaster.awaddr(11 downto 0) = x"100") then
-        v.ADCReadStart := '1';
-      elsif (axilWriteMaster.awaddr(11 downto 0) < x"100") then
-        v.FifoWr := '1';
+      -- Check for a write request
+      if (axilStatus.writeEnable = '1') then
+         -- Check for start
+         if (axilWriteMaster.awaddr(11 downto 0) = x"100") then
+            v.ADCReadStart := '1';
+         elsif (axilWriteMaster.awaddr(11 downto 0) < x"100") then
+            v.FifoWr := '1';
+         end if;
+         -- Send AXI-Lite Response
+         axiSlaveWriteResponse(v.axilWriteSlave, AXI_RESP_OK_C);
       end if;
-      -- Send AXI-Lite Response
-      axiSlaveWriteResponse(v.axilWriteSlave, AXI_RESP_OK_C);
-    end if;
 
-    -- Check for a read request
-    if (axilStatus.readEnable = '1') then
-      -- Wait 1 cycle for data to get out of the DPMEM pipeline
-      v.RdDelay := '1';
-    end if;
+      -- Check for a read request
+      if (axilStatus.readEnable = '1') then
+         -- Wait 1 cycle for data to get out of the DPMEM pipeline
+         v.RdDelay := '1';
+      end if;
 
-    if (r.RdDelay = '1') then
-      -- Forward the read data from the RAM
-      v.axilReadSlave.rdata := LTCDataOut;
-      -- Send AXI-Lite Response
-      axiSlaveReadResponse(v.axilReadSlave, AXI_RESP_OK_C);
-    end if;
+      if (r.RdDelay = '1') then
+         -- Forward the read data from the RAM
+         v.axilReadSlave.rdata := LTCDataOut;
+         -- Send AXI-Lite Response
+         axiSlaveReadResponse(v.axilReadSlave, AXI_RESP_OK_C);
+      end if;
 
-    -- Reset
-    if (axilRst = '1') then
-      v := REG_INIT_C;
-    end if;
+      -- Reset
+      if (axilRst = '1') then
+         v := REG_INIT_C;
+      end if;
 
-    -- Register the variable for next clock cycle
-    rin <= v;
+      -- Register the variable for next clock cycle
+      rin <= v;
 
-    -- Outputs 
-    axilReadSlave  <= r.axilReadSlave;
-    axilWriteSlave <= r.axilWriteSlave;
+      -- Outputs 
+      axilReadSlave  <= r.axilReadSlave;
+      axilWriteSlave <= r.axilWriteSlave;
 
-    -- Fifo Data is the address and 24 bit data to the ADC which
-    -- becomes the ADC register and 24 bit data to write
-    FifoDataIn <= axilWriteMaster.awaddr(9 downto 2) & axilWriteMaster.wdata(23 downto 0);
+      -- Fifo Data is the address and 24 bit data to the ADC which
+      -- becomes the ADC register and 24 bit data to write
+      FifoDataIn <= axilWriteMaster.awaddr(9 downto 2) & axilWriteMaster.wdata(23 downto 0);
 
-  end process;
+   end process;
 
-  seq : process (axilClk) is
-  begin
-    if (rising_edge(axilClk)) then
-      r <= rin after TPD_G;
-    end if;
-  end process seq;
+   seq : process (axilClk) is
+   begin
+      if (rising_edge(axilClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
 
-  u_SA56004 : entity work.SA56004I2CCore
-    generic map (
-      TPD_G           => 1 ns,
-      ADDR_WIDTH_G    => 8,
-      POLL_TIMEOUT_G  => 16,
-      I2C_ADDR_G      => "1001000",     -- SA56004A Addr1, Addr0 = "00"
-      I2C_SCL_FREQ_G  => 100.0E+3,      -- units of Hz
-      I2C_MIN_PULSE_G => 100.0E-9       -- units of seconds
-      )
-    port map (
-      Clock     => axilClk,
-      Reset     => axilRst,
+   u_SA56004 : entity work.SA56004I2CCore
+      generic map (
+         TPD_G           => 1 ns,
+         ADDR_WIDTH_G    => 8,
+         POLL_TIMEOUT_G  => 16,
+         I2C_ADDR_G      => "1001000",  -- SA56004A Addr1, Addr0 = "00"
+         I2C_SCL_FREQ_G  => 100.0E+3,   -- units of Hz
+         I2C_MIN_PULSE_G => 100.0E-9    -- units of seconds
+         )
+      port map (
+         Clock           => axilClk,
+         Reset           => axilRst,
 --      StartRead => r.ADCReadStart,
-      StartRead => StartConv,
-      -- Serial interface
-      i2ci      => i2ci,
-      i2co      => i2co,
-      -- Fifo Interface for writes
-      WrStrb    => r.FifoWr,
-      DataIn    => FifoDataIn,
-      -- Dual Port memory for output
-      RdMemAddr => axilReadMaster.araddr(6 downto 2),
-      MemDout   => SA56004DataOut,
-		SA56004ComFault => SA56004ComFault
-      );
+         StartRead       => StartConv,
+         -- Serial interface
+         i2ci            => i2ci,
+         i2co            => i2co,
+         -- Fifo Interface for writes
+         WrStrb          => r.FifoWr,
+         DataIn          => FifoDataIn,
+         -- Dual Port memory for output
+         RdMemAddr       => axilReadMaster.araddr(6 downto 2),
+         MemDout         => SA56004DataOut,
+         SA56004ComFault => SA56004ComFault
+         );
 
 end;
 

--- a/rtl/i2c/SA56004Axil.vhd
+++ b/rtl/i2c/SA56004Axil.vhd
@@ -1,0 +1,173 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      SA56004Axil.vhd -
+--
+--      Copyright(c) SLAC National Accelerator Laboratory 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/14/2018 8:56:03 AM
+--      Last change: JO 6/11/2018 1:15:46 PM
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+
+use work.StdRtlPkg.all;
+use work.AxiStreamPkg.all;
+use work.AxiLitePkg.all;
+use work.I2cPkg.all;
+
+entity SA56004Axil is
+  generic (
+    TPD_G            : time             := 1 ns;
+    AXI_BASE_ADDR_G  : slv(31 downto 0) := x"00000000";
+    AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C
+    );
+  port (
+    -- AXI-Lite Interface
+    axilClk         : in    sl;
+    axilRst         : in    sl;
+    axilReadMaster  : in    AxiLiteReadMasterType;
+    axilReadSlave   : out   AxiLiteReadSlaveType;
+    axilWriteMaster : in    AxiLiteWriteMasterType;
+    axilWriteSlave  : out   AxiLiteWriteSlaveType;
+    -- I2C bus
+    i2ci            : inout i2c_in_type;
+    i2co            : inout i2c_out_type;
+    -- Start Conversion
+    StartConv       : in    sl;
+    -- I2C fault
+    SA56004ComFault : out   sl
+    );
+end entity SA56004Axil;
+
+architecture Behavioral of SA56004Axil is
+
+  type RegType is record
+    ADCReadStart   : sl;
+    FifoWr         : sl;
+    RdDelay        : sl;
+    axilReadSlave  : AxiLiteReadSlaveType;
+    axilWriteSlave : AxiLiteWriteSlaveType;
+  end record;
+
+  constant REG_INIT_C : RegType := (
+    ADCReadStart   => '0',
+    FifoWr         => '0',
+    RdDelay        => '0',
+    axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+    axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
+
+  signal r          : RegType := REG_INIT_C;
+  signal rin        : RegType;
+  signal FifoDataIn : slv(31 downto 0);
+  signal LTCDataOut : slv(31 downto 0);
+  signal Convert    : sl;
+
+begin
+
+  comb : process (LTCDataOut, axilReadMaster, axilRst, axilWriteMaster, r) is
+    variable v          : RegType;
+    variable axilStatus : AxiLiteStatusType;
+  begin
+    -- Latch the current value
+    v := r;
+
+    -- Reset the strobes
+    v.ADCReadStart := '0';
+    v.FifoWr       := '0';
+    v.RdDelay      := '0';
+
+    -- Determine the transaction type
+    axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
+
+    -- Check for a write request
+    if (axilStatus.writeEnable = '1') then
+      -- Check for start
+      if (axilWriteMaster.awaddr(11 downto 0) = x"100") then
+        v.ADCReadStart := '1';
+      elsif (axilWriteMaster.awaddr(11 downto 0) < x"100") then
+        v.FifoWr := '1';
+      end if;
+      -- Send AXI-Lite Response
+      axiSlaveWriteResponse(v.axilWriteSlave, AXI_RESP_OK_C);
+    end if;
+
+    -- Check for a read request
+    if (axilStatus.readEnable = '1') then
+      -- Wait 1 cycle for data to get out of the DPMEM pipeline
+      v.RdDelay := '1';
+    end if;
+
+    if (r.RdDelay = '1') then
+      -- Forward the read data from the RAM
+      v.axilReadSlave.rdata := LTCDataOut;
+      -- Send AXI-Lite Response
+      axiSlaveReadResponse(v.axilReadSlave, AXI_RESP_OK_C);
+    end if;
+
+    -- Reset
+    if (axilRst = '1') then
+      v := REG_INIT_C;
+    end if;
+
+    -- Register the variable for next clock cycle
+    rin <= v;
+
+    -- Outputs 
+    axilReadSlave  <= r.axilReadSlave;
+    axilWriteSlave <= r.axilWriteSlave;
+
+    -- Fifo Data is the address and 24 bit data to the ADC which
+    -- becomes the ADC register and 24 bit data to write
+    FifoDataIn <= axilWriteMaster.awaddr(9 downto 2) & axilWriteMaster.wdata(23 downto 0);
+
+  end process;
+
+  seq : process (axilClk) is
+  begin
+    if (rising_edge(axilClk)) then
+      r <= rin after TPD_G;
+    end if;
+  end process seq;
+
+  u_SA56004 : entity work.SA56004I2CCore
+    generic map (
+      TPD_G           => 1 ns,
+      ADDR_WIDTH_G    => 8,
+      POLL_TIMEOUT_G  => 16,
+      I2C_ADDR_G      => "1001000",     -- SA56004A Addr1, Addr0 = "00"
+      I2C_SCL_FREQ_G  => 100.0E+3,      -- units of Hz
+      I2C_MIN_PULSE_G => 100.0E-9       -- units of seconds
+      )
+    port map (
+      Clock     => axilClk,
+      Reset     => axilRst,
+--      StartRead => r.ADCReadStart,
+      StartRead => StartConv,
+      -- Serial interface
+      i2ci      => i2ci,
+      i2co      => i2co,
+      -- Fifo Interface for writes
+      WrStrb    => r.FifoWr,
+      DataIn    => FifoDataIn,
+      -- Dual Port memory for output
+      RdMemAddr => axilReadMaster.araddr(6 downto 2),
+      MemDout   => SA56004DataOut,
+		SA56004ComFault => SA56004ComFault
+      );
+
+end;
+

--- a/rtl/i2c/SA56004I2CCore.vhd
+++ b/rtl/i2c/SA56004I2CCore.vhd
@@ -1,0 +1,432 @@
+-----------------------------------------------------------------
+--                                                             --
+-----------------------------------------------------------------
+--
+--      SA56004I2CCore.vhd -
+--
+--      Copyright(c) SLAC 2000
+--
+--      Author: Jeff Olsen
+--      Created on: 2/4/2008 1:32:47 PM
+--      Last change: JO 6/11/2018 1:29:25 PM
+--
+----------------------------------------------------------------------------------
+-- Company:
+-- Engineer:
+--
+-- Create Date:    16:30:20 01/31/2008
+-- Design Name:
+-- Module Name:    SA56004I2CCore - Behavioral
+-- Project Name:
+-- Target Devices:
+-- Tool versions:
+-- Description:
+--
+-- Dependencies:
+--
+-- Revision:
+-- Revision 0.01 - File Created
+-- Additional Comments:
+--
+-------------------------------------------------------------------------------
+-- This file is part of 'LSST Firmware'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'LSST Firmware', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+
+-------------------------------------------------------------------------------
+-- 6/11/18
+-- jjo
+-- Only reading temperature from register 0
+-- This code was taken from the LTC2945 Power Monitor IC.
+-- That code can read and write from/to the LTC2945
+-- I removed all of that from this code until needed.
+-- I left the fifo and ram in case I update this to a full
+-- driver for the SA56004
+-------------------------------------------------------------------------------
+
+
+library IEEE;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.StdRtlPkg.all;
+use work.I2cPkg.all;
+use work.LsstI2cPkg.all;
+
+library work;
+
+entity SA56004I2CCore is
+  generic (
+    TPD_G           : time            := 1 ns;
+    ADDR_WIDTH_G    : positive        := 16;
+    POLL_TIMEOUT_G  : positive        := 16;
+    I2C_ADDR_G      : slv(6 downto 0) := "1010000";
+    I2C_SCL_FREQ_G  : real            := 100.0E+3;  -- units of Hz
+    I2C_MIN_PULSE_G : real            := 100.0E-9;  -- units of seconds
+    AXI_CLK_FREQ_G  : real            := 156.25E+6  -- units of Hz
+
+    );
+  port (
+    Clock           : in  sl;
+    Reset           : in  sl;
+    StartRead       : in  sl;
+-- Serial interface
+    i2ci            : in  i2c_in_type;
+    i2co            : out i2c_out_type;
+-- Fifo Interface for writes
+    WrStrb          : in  sl;
+    DataIn          : in  slv(31 downto 0);
+-- Dual Port memory for output
+    RdMemAddr       : in  slv(4 downto 0);
+    MemDout         : out slv(31 downto 0);
+    -- I2C Fault
+    SA56004ComFault :     out sl
+
+    );
+end SA56004I2CCore;
+
+architecture Behavioral of SA56004I2CCore is
+
+  -- Note: PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
+  --       FILTER_G = (min_pulse_time / clk_period) + 1
+  constant I2C_SCL_5xFREQ_C : real    := 5.0 * I2C_SCL_FREQ_G;
+  constant PRESCALE_C       : natural := (getTimeRatio(AXI_CLK_FREQ_G, I2C_SCL_5xFREQ_C)) - 1;
+  constant FILTER_C         : natural := natural(AXI_CLK_FREQ_G * I2C_MIN_PULSE_G) + 1;
+
+  constant ADDR_SIZE_C : slv(1 downto 0) := toSlv(wordCount(ADDR_WIDTH_G, 8) - 1, 2);
+--  constant DATA_SIZE_C : slv(1 downto 0) := toSlv(wordCount(32, 8) - 1, 2);
+  constant I2C_ADDR_C  : slv(9 downto 0) := ("000" & I2C_ADDR_G);
+  constant TIMEOUT_C   : natural         := (getTimeRatio(AXI_CLK_FREQ_G, 200.0)) - 1;  -- 5 ms timeout   
+
+  constant MY_I2C_REG_MASTER_IN_INIT_C : I2cRegMasterInType := (
+    i2cAddr     => I2C_ADDR_C,
+    tenbit      => '0',
+    regAddr     => (others => '0'),
+    regWrData   => (others => '0'),
+    regOp       => '0',                 -- 1 for write, 0 for read
+    regAddrSkip => '0',
+    regAddrSize => ADDR_SIZE_C,
+    regDataSize => "00",
+    regReq      => '0',
+    busReq      => '0',
+    endianness  => '1',                 -- Big endian
+    repeatStart => '1'
+    );
+
+
+  type StateType is (
+    IDLE_S,
+    READ_ACK_S,
+    NEXT_REG_S,
+    FIFO_DEL_S,
+    WRITE_DATA_S,
+    WRITE_ACK_S,
+    WRITE_DONE_S
+    );
+
+  type RegType is record
+    timer      : natural range 0 to TIMEOUT_C;
+    FifoRdStrb : sl;
+    d_StartRd  : sl;
+    RamIn      : slv(31 downto 0);
+    WrdCnt     : integer range 0 to 24;  -- Current Word
+    RegAddr    : integer range 0 to 49;  -- Address in LTC
+    DelCnt     : integer range 0 to 16535;
+    StoreWrd   : sl;
+    DpRamAddr  : slv(4 downto 0);
+    byteShift  : slv(31 downto 0);
+    regIn      : I2cRegMasterInType;
+    state      : StateType;
+  end record;
+
+  constant REG_INIT_C : RegType := (
+    timer      => 0,
+    FifoRdStrb => '0',
+    d_StartRd  => '0',
+    RamIn      => (others => '0'),
+    WrdCnt     => 0,
+    RegAddr    => 0,
+    DelCnt     => 0,
+    StoreWrd   => '0',
+    DpRamAddr  => (others => '0'),
+    byteShift  => (others => '0'),
+    regIn      => MY_I2C_REG_MASTER_IN_INIT_C,
+    state      => IDLE_S
+    );
+
+  signal r   : RegType := REG_INIT_C;
+  signal rin : RegType;
+
+  signal regOut : I2cRegMasterOutType;
+
+  signal FifoDin   : slv(31 downto 0);
+  signal FifoDout  : slv(31 downto 0);
+  signal FifoEmpty : sl;
+  signal DpDout    : slv(31 downto 0);
+  signal WrData   : slv(31 downto 0);
+
+--
+-- These arrays held the address and byte size for the LTC2945
+-- However, on the SA56004, the read address and write address are different
+-- Would need another array to fix this probably
+-- Read Local Set point address 5, write address B
+--
+
+  type Bytes2Read_t is array (0 downto 0) of integer range 1 to 3;
+  constant Bytes2Read : Bytes2Read_t :=
+    (
+      1
+      );
+
+  type Addr2Write_t is array (0 downto 0) of integer range 0 to 48;
+  constant Addr2Write : Addr2Write_t :=
+    (
+	 0
+      );
+
+begin
+
+  FifoDin         <= DataIn;
+  MemDout         <= DpDout;
+  SA56004ComFault <= regOut.regFail;
+
+  comb : process (r, Reset, StartRead, RegOut, FifoDout, FifoEmpty, WrData) is
+    variable v     : RegType;
+    variable WAddr : integer range 0 to 0;
+  begin
+
+    v     := r;
+    WAddr := to_integer(unsigned(FifoDout(31 downto 24)));
+    WrData <= (Others => '0');
+
+
+    v.FifoRdStrb := '0';
+    v.d_StartRd  := StartRead;
+    v.StoreWrd   := '0';
+
+    v.RamIn := regout.regRdData(31 downto 0);
+
+    case r.State is
+
+      when IDLE_s =>
+        v.WrdCnt                                 := 0;
+        v.RegAddr                                := 0;
+        v.regIn.regOp                            := '0';  -- Read operation
+        v.regIn.repeatStart                      := '1';
+        v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
+        v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
+        v.DpRamAddr                              := toslv(r.wrdCnt, 5);
+
+        if regOut.regAck = '0' then
+          if ((StartRead = '1') and (r.d_StartRd = '0')) then
+            -- Send read transaction to I2cRegMaster
+            v.regIn.regReq := '1';
+            -- Next state
+            v.state := READ_ACK_S;
+--
+-- Commented out the write
+--          elsif (FifoEmpty = '0') then
+--            -- Set the flag
+--            -- Send write transaction to I2cRegMaster
+--            v.FifoRdStrb := '1';
+--
+--            -- Next state
+--            v.state := FIFO_DEL_S;
+--
+          end if;
+        end if;
+
+      when Read_ACK_S =>
+        v.DpRamAddr := toslv(r.wrdCnt, 5);
+        -- Wait for completion
+        if (regOut.regAck = '1') then
+          -- Reset the flag
+          v.regIn.regReq := '0';
+          v.RegAddr      := r.RegAddr + Bytes2Read(r.WrdCnt);
+
+          v.StoreWrd := '1';
+          v.wrdCnt   := r.wrdCnt + 1;
+
+          -- Check for I2C failure
+          if (regOut.regFail = '1') then
+            v.state := IDLE_S;
+          elsif (r.WrdCnt = 0) then
+            v.state := IDLE_S;
+          else
+            v.DelCnt := 5;  -- this is probably not necessary. I used it to make a gap in the scope display
+            v.state  := NEXT_REG_S;
+          end if;
+        end if;
+
+      when NEXT_REG_S =>
+        if regOut.regAck = '0' then
+          v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
+          v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
+
+          if (R.DelCnt = 0) then
+            v.regIn.regReq := '1';
+            v.state        := READ_ACK_S;
+          else
+            v.DelCnt := r.DelCnt - 1;
+          end if;
+        end if;
+
+      when FIFO_DEL_S =>
+        v.state := WRITE_DATA_S;
+
+      when WRITE_DATA_S =>
+        v.regIn.regReq                           := '1';
+        v.regIn.regOp                            := '1';  -- Write operation
+        v.regIn.repeatStart                      := '1';
+        v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(Addr2Write(WAddr), ADDR_WIDTH_G);
+        v.regIn.regDataSize                      := toslv(Bytes2Read(WAddr)-1, 2);
+
+        v.regIn.regWrData := WrData;
+        v.state           := WRITE_ACK_S;
+
+
+      when WRITE_ACK_S =>
+
+        -- Wait for completion
+        if regOut.regAck = '1' then
+          -- Reset the flag
+          v.regIn.regReq := '0';
+          -- Check for I2C failure
+          if regOut.regFail = '1' then
+            -- Next state
+            v.state := IDLE_S;
+          else
+            -- Next state
+            v.state := WRITE_DONE_S;
+          end if;
+        end if;
+
+      when WRITE_DONE_S =>
+        if regOut.regAck = '0' then
+          -- Next state
+          v.state := IDLE_S;
+        end if;
+
+    end case;
+
+    if (Reset = '1') then
+      v := REG_INIT_C;
+    end if;
+
+    rin <= v;
+
+  end process comb;
+
+  seq : process (Clock) is
+  begin
+    if (rising_edge(Clock)) then
+      r <= rin after TPD_G;
+    end if;
+  end process seq;
+
+  U_I2cRegMaster : entity work.I2cRegMaster
+    generic map(
+      TPD_G                => TPD_G,
+      OUTPUT_EN_POLARITY_G => 0,
+      FILTER_G             => FILTER_C,
+      PRESCALE_G           => PRESCALE_C
+      )
+    port map (
+      -- Clock and Reset
+      clk    => clock,
+      srst   => reset,
+      -- I2C Register Interface
+      regIn  => r.regIn,
+      regOut => regOut,
+      -- I2C Port Interface
+      i2ci   => i2ci,
+      i2co   => i2co
+      );
+
+  u_Ram : entity work.SimpleDualPortRam
+    generic map (
+      TPD_G          => 1 ns,           -- Simulated propagation delay 1 ns;
+      RST_POLARITY_G => '1',  -- '1' for active high rst, '0' for active low      
+      BRAM_EN_G      => false,
+      DOB_REG_G      => false,  -- Extra reg on doutb (folded into BRAM)
+      ALTERA_SYN_G   => false,
+      ALTERA_RAM_G   => "M9K",
+      BYTE_WR_EN_G   => false,
+      DATA_WIDTH_G   => 32,
+      BYTE_WIDTH_G   => 8,    -- If BRAM, should be multiple or 8 or 9
+      ADDR_WIDTH_G   => 5,
+      INIT_G         => "0"
+      )
+    port map (
+      -- Port A     
+      clka    => Clock,
+      ena     => '1',
+      wea     => r.StoreWrd,
+      weaByte => "1111",
+      addra   => r.DpRamAddr,
+      dina    => r.ramin,
+      -- Port
+      clkb    => Clock,
+      enb     => '1',
+      rstb    => Reset,
+      addrb   => RdMemAddr(4 downto 0),
+      doutb   => DpDout
+      );
+
+  u_Fifo : entity work.Fifo
+    generic map (
+      TPD_G           => 1 ns,
+      RST_POLARITY_G  => '1',    -- '1' for active high rst, '0' for active low
+      RST_ASYNC_G     => false,
+      GEN_SYNC_FIFO_G => true,
+      BRAM_EN_G       => true,
+      FWFT_EN_G       => false,
+      USE_DSP48_G     => "no",
+      ALTERA_SYN_G    => false,
+      ALTERA_RAM_G    => "M9K",
+      USE_BUILT_IN_G  => false,  --if set to true, this module is only xilinx compatible only!!!
+      XIL_DEVICE_G    => "7SERIES",     --xilinx only generic parameter    
+      SYNC_STAGES_G   => 3,
+      PIPE_STAGES_G   => 0,
+      DATA_WIDTH_G    => 32,
+      ADDR_WIDTH_G    => 5,
+      INIT_G          => "0",
+      FULL_THRES_G    => 1,
+      EMPTY_THRES_G   => 1
+      )
+    port map (
+      -- Resets
+      rst    => Reset,
+      --Write Ports (wr_clk domain)
+      wr_clk => Clock,
+      wr_en  => WrStrb,
+      din    => FifoDin,
+--      wr_data_count => open,
+--      wr_ack        => open,
+--      overflow      => open,
+--      prog_full     => open,
+--      almost_full   => open,
+--      full          => open,
+--      not_full      => open,
+      --Read Ports (rd_clk domain)
+      rd_clk => '0',                    --unused if GEN_SYNC_FIFO_G = true
+      rd_en  => r.FifoRdStrb,
+      dout   => FifoDout,
+--      rd_data_count => open,
+--      valid         => open,
+--      underflow     => open,
+--      prog_empty    => open,
+--      almost_empty => open,
+      empty  => FifoEmpty
+      );
+
+
+
+end Behavioral;
+

--- a/rtl/i2c/SA56004I2CCore.vhd
+++ b/rtl/i2c/SA56004I2CCore.vhd
@@ -59,117 +59,115 @@ use work.StdRtlPkg.all;
 use work.I2cPkg.all;
 use work.LsstI2cPkg.all;
 
-library work;
-
 entity SA56004I2CCore is
-  generic (
-    TPD_G           : time            := 1 ns;
-    ADDR_WIDTH_G    : positive        := 16;
-    POLL_TIMEOUT_G  : positive        := 16;
-    I2C_ADDR_G      : slv(6 downto 0) := "1010000";
-    I2C_SCL_FREQ_G  : real            := 100.0E+3;  -- units of Hz
-    I2C_MIN_PULSE_G : real            := 100.0E-9;  -- units of seconds
-    AXI_CLK_FREQ_G  : real            := 156.25E+6  -- units of Hz
+   generic (
+      TPD_G           : time            := 1 ns;
+      ADDR_WIDTH_G    : positive        := 16;
+      POLL_TIMEOUT_G  : positive        := 16;
+      I2C_ADDR_G      : slv(6 downto 0) := "1010000";
+      I2C_SCL_FREQ_G  : real            := 100.0E+3;  -- units of Hz
+      I2C_MIN_PULSE_G : real            := 100.0E-9;  -- units of seconds
+      AXI_CLK_FREQ_G  : real            := 156.25E+6  -- units of Hz
 
-    );
-  port (
-    Clock           : in  sl;
-    Reset           : in  sl;
-    StartRead       : in  sl;
+      );
+   port (
+      Clock           : in  sl;
+      Reset           : in  sl;
+      StartRead       : in  sl;
 -- Serial interface
-    i2ci            : in  i2c_in_type;
-    i2co            : out i2c_out_type;
+      i2ci            : in  i2c_in_type;
+      i2co            : out i2c_out_type;
 -- Fifo Interface for writes
-    WrStrb          : in  sl;
-    DataIn          : in  slv(31 downto 0);
+      WrStrb          : in  sl;
+      DataIn          : in  slv(31 downto 0);
 -- Dual Port memory for output
-    RdMemAddr       : in  slv(4 downto 0);
-    MemDout         : out slv(31 downto 0);
-    -- I2C Fault
-    SA56004ComFault :     out sl
+      RdMemAddr       : in  slv(4 downto 0);
+      MemDout         : out slv(31 downto 0);
+      -- I2C Fault
+      SA56004ComFault : out sl
 
-    );
+      );
 end SA56004I2CCore;
 
 architecture Behavioral of SA56004I2CCore is
 
-  -- Note: PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
-  --       FILTER_G = (min_pulse_time / clk_period) + 1
-  constant I2C_SCL_5xFREQ_C : real    := 5.0 * I2C_SCL_FREQ_G;
-  constant PRESCALE_C       : natural := (getTimeRatio(AXI_CLK_FREQ_G, I2C_SCL_5xFREQ_C)) - 1;
-  constant FILTER_C         : natural := natural(AXI_CLK_FREQ_G * I2C_MIN_PULSE_G) + 1;
+   -- Note: PRESCALE_G = (clk_freq / (5 * i2c_freq)) - 1
+   --       FILTER_G = (min_pulse_time / clk_period) + 1
+   constant I2C_SCL_5xFREQ_C : real    := 5.0 * I2C_SCL_FREQ_G;
+   constant PRESCALE_C       : natural := (getTimeRatio(AXI_CLK_FREQ_G, I2C_SCL_5xFREQ_C)) - 1;
+   constant FILTER_C         : natural := natural(AXI_CLK_FREQ_G * I2C_MIN_PULSE_G) + 1;
 
-  constant ADDR_SIZE_C : slv(1 downto 0) := toSlv(wordCount(ADDR_WIDTH_G, 8) - 1, 2);
+   constant ADDR_SIZE_C : slv(1 downto 0) := toSlv(wordCount(ADDR_WIDTH_G, 8) - 1, 2);
 --  constant DATA_SIZE_C : slv(1 downto 0) := toSlv(wordCount(32, 8) - 1, 2);
-  constant I2C_ADDR_C  : slv(9 downto 0) := ("000" & I2C_ADDR_G);
-  constant TIMEOUT_C   : natural         := (getTimeRatio(AXI_CLK_FREQ_G, 200.0)) - 1;  -- 5 ms timeout   
+   constant I2C_ADDR_C  : slv(9 downto 0) := ("000" & I2C_ADDR_G);
+   constant TIMEOUT_C   : natural         := (getTimeRatio(AXI_CLK_FREQ_G, 200.0)) - 1;  -- 5 ms timeout   
 
-  constant MY_I2C_REG_MASTER_IN_INIT_C : I2cRegMasterInType := (
-    i2cAddr     => I2C_ADDR_C,
-    tenbit      => '0',
-    regAddr     => (others => '0'),
-    regWrData   => (others => '0'),
-    regOp       => '0',                 -- 1 for write, 0 for read
-    regAddrSkip => '0',
-    regAddrSize => ADDR_SIZE_C,
-    regDataSize => "00",
-    regReq      => '0',
-    busReq      => '0',
-    endianness  => '1',                 -- Big endian
-    repeatStart => '1'
-    );
+   constant MY_I2C_REG_MASTER_IN_INIT_C : I2cRegMasterInType := (
+      i2cAddr     => I2C_ADDR_C,
+      tenbit      => '0',
+      regAddr     => (others => '0'),
+      regWrData   => (others => '0'),
+      regOp       => '0',               -- 1 for write, 0 for read
+      regAddrSkip => '0',
+      regAddrSize => ADDR_SIZE_C,
+      regDataSize => "00",
+      regReq      => '0',
+      busReq      => '0',
+      endianness  => '1',               -- Big endian
+      repeatStart => '1'
+      );
 
 
-  type StateType is (
-    IDLE_S,
-    READ_ACK_S,
-    NEXT_REG_S,
-    FIFO_DEL_S,
-    WRITE_DATA_S,
-    WRITE_ACK_S,
-    WRITE_DONE_S
-    );
+   type StateType is (
+      IDLE_S,
+      READ_ACK_S,
+      NEXT_REG_S,
+      FIFO_DEL_S,
+      WRITE_DATA_S,
+      WRITE_ACK_S,
+      WRITE_DONE_S
+      );
 
-  type RegType is record
-    timer      : natural range 0 to TIMEOUT_C;
-    FifoRdStrb : sl;
-    d_StartRd  : sl;
-    RamIn      : slv(31 downto 0);
-    WrdCnt     : integer range 0 to 24;  -- Current Word
-    RegAddr    : integer range 0 to 49;  -- Address in LTC
-    DelCnt     : integer range 0 to 16535;
-    StoreWrd   : sl;
-    DpRamAddr  : slv(4 downto 0);
-    byteShift  : slv(31 downto 0);
-    regIn      : I2cRegMasterInType;
-    state      : StateType;
-  end record;
+   type RegType is record
+      timer      : natural range 0 to TIMEOUT_C;
+      FifoRdStrb : sl;
+      d_StartRd  : sl;
+      RamIn      : slv(31 downto 0);
+      WrdCnt     : integer range 0 to 24;  -- Current Word
+      RegAddr    : integer range 0 to 49;  -- Address in LTC
+      DelCnt     : integer range 0 to 16535;
+      StoreWrd   : sl;
+      DpRamAddr  : slv(4 downto 0);
+      byteShift  : slv(31 downto 0);
+      regIn      : I2cRegMasterInType;
+      state      : StateType;
+   end record;
 
-  constant REG_INIT_C : RegType := (
-    timer      => 0,
-    FifoRdStrb => '0',
-    d_StartRd  => '0',
-    RamIn      => (others => '0'),
-    WrdCnt     => 0,
-    RegAddr    => 0,
-    DelCnt     => 0,
-    StoreWrd   => '0',
-    DpRamAddr  => (others => '0'),
-    byteShift  => (others => '0'),
-    regIn      => MY_I2C_REG_MASTER_IN_INIT_C,
-    state      => IDLE_S
-    );
+   constant REG_INIT_C : RegType := (
+      timer      => 0,
+      FifoRdStrb => '0',
+      d_StartRd  => '0',
+      RamIn      => (others => '0'),
+      WrdCnt     => 0,
+      RegAddr    => 0,
+      DelCnt     => 0,
+      StoreWrd   => '0',
+      DpRamAddr  => (others => '0'),
+      byteShift  => (others => '0'),
+      regIn      => MY_I2C_REG_MASTER_IN_INIT_C,
+      state      => IDLE_S
+      );
 
-  signal r   : RegType := REG_INIT_C;
-  signal rin : RegType;
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
 
-  signal regOut : I2cRegMasterOutType;
+   signal regOut : I2cRegMasterOutType;
 
-  signal FifoDin   : slv(31 downto 0);
-  signal FifoDout  : slv(31 downto 0);
-  signal FifoEmpty : sl;
-  signal DpDout    : slv(31 downto 0);
-  signal WrData   : slv(31 downto 0);
+   signal FifoDin   : slv(31 downto 0);
+   signal FifoDout  : slv(31 downto 0);
+   signal FifoEmpty : sl;
+   signal DpDout    : slv(31 downto 0);
+   signal WrData    : slv(31 downto 0);
 
 --
 -- These arrays held the address and byte size for the LTC2945
@@ -178,57 +176,57 @@ architecture Behavioral of SA56004I2CCore is
 -- Read Local Set point address 5, write address B
 --
 
-  type Bytes2Read_t is array (0 downto 0) of integer range 1 to 3;
-  constant Bytes2Read : Bytes2Read_t :=
-    (
-      1
-      );
+   type Bytes2Read_t is array (0 downto 0) of integer range 1 to 3;
+   constant Bytes2Read : Bytes2Read_t :=
+      (
+         1
+         );
 
-  type Addr2Write_t is array (0 downto 0) of integer range 0 to 48;
-  constant Addr2Write : Addr2Write_t :=
-    (
-	 0
-      );
+   type Addr2Write_t is array (0 downto 0) of integer range 0 to 48;
+   constant Addr2Write : Addr2Write_t :=
+      (
+         0
+         );
 
 begin
 
-  FifoDin         <= DataIn;
-  MemDout         <= DpDout;
-  SA56004ComFault <= regOut.regFail;
+   FifoDin         <= DataIn;
+   MemDout         <= DpDout;
+   SA56004ComFault <= regOut.regFail;
 
-  comb : process (r, Reset, StartRead, RegOut, FifoDout, FifoEmpty, WrData) is
-    variable v     : RegType;
-    variable WAddr : integer range 0 to 0;
-  begin
+   comb : process (r, Reset, StartRead, RegOut, FifoDout, FifoEmpty, WrData) is
+      variable v     : RegType;
+      variable WAddr : integer range 0 to 0;
+   begin
 
-    v     := r;
-    WAddr := to_integer(unsigned(FifoDout(31 downto 24)));
-    WrData <= (Others => '0');
+      v      := r;
+      WAddr  := to_integer(unsigned(FifoDout(31 downto 24)));
+      WrData <= (others => '0');
 
 
-    v.FifoRdStrb := '0';
-    v.d_StartRd  := StartRead;
-    v.StoreWrd   := '0';
+      v.FifoRdStrb := '0';
+      v.d_StartRd  := StartRead;
+      v.StoreWrd   := '0';
 
-    v.RamIn := regout.regRdData(31 downto 0);
+      v.RamIn := regout.regRdData(31 downto 0);
 
-    case r.State is
+      case r.State is
 
-      when IDLE_s =>
-        v.WrdCnt                                 := 0;
-        v.RegAddr                                := 0;
-        v.regIn.regOp                            := '0';  -- Read operation
-        v.regIn.repeatStart                      := '1';
-        v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
-        v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
-        v.DpRamAddr                              := toslv(r.wrdCnt, 5);
+         when IDLE_s =>
+            v.WrdCnt                                 := 0;
+            v.RegAddr                                := 0;
+            v.regIn.regOp                            := '0';  -- Read operation
+            v.regIn.repeatStart                      := '1';
+            v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
+            v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
+            v.DpRamAddr                              := toslv(r.wrdCnt, 5);
 
-        if regOut.regAck = '0' then
-          if ((StartRead = '1') and (r.d_StartRd = '0')) then
-            -- Send read transaction to I2cRegMaster
-            v.regIn.regReq := '1';
-            -- Next state
-            v.state := READ_ACK_S;
+            if regOut.regAck = '0' then
+               if ((StartRead = '1') and (r.d_StartRd = '0')) then
+                  -- Send read transaction to I2cRegMaster
+                  v.regIn.regReq := '1';
+                  -- Next state
+                  v.state        := READ_ACK_S;
 --
 -- Commented out the write
 --          elsif (FifoEmpty = '0') then
@@ -239,174 +237,174 @@ begin
 --            -- Next state
 --            v.state := FIFO_DEL_S;
 --
-          end if;
-        end if;
+               end if;
+            end if;
 
-      when Read_ACK_S =>
-        v.DpRamAddr := toslv(r.wrdCnt, 5);
-        -- Wait for completion
-        if (regOut.regAck = '1') then
-          -- Reset the flag
-          v.regIn.regReq := '0';
-          v.RegAddr      := r.RegAddr + Bytes2Read(r.WrdCnt);
+         when Read_ACK_S =>
+            v.DpRamAddr := toslv(r.wrdCnt, 5);
+            -- Wait for completion
+            if (regOut.regAck = '1') then
+               -- Reset the flag
+               v.regIn.regReq := '0';
+               v.RegAddr      := r.RegAddr + Bytes2Read(r.WrdCnt);
 
-          v.StoreWrd := '1';
-          v.wrdCnt   := r.wrdCnt + 1;
+               v.StoreWrd := '1';
+               v.wrdCnt   := r.wrdCnt + 1;
 
-          -- Check for I2C failure
-          if (regOut.regFail = '1') then
-            v.state := IDLE_S;
-          elsif (r.WrdCnt = 0) then
-            v.state := IDLE_S;
-          else
-            v.DelCnt := 5;  -- this is probably not necessary. I used it to make a gap in the scope display
-            v.state  := NEXT_REG_S;
-          end if;
-        end if;
+               -- Check for I2C failure
+               if (regOut.regFail = '1') then
+                  v.state := IDLE_S;
+               elsif (r.WrdCnt = 0) then
+                  v.state := IDLE_S;
+               else
+                  v.DelCnt := 5;  -- this is probably not necessary. I used it to make a gap in the scope display
+                  v.state  := NEXT_REG_S;
+               end if;
+            end if;
 
-      when NEXT_REG_S =>
-        if regOut.regAck = '0' then
-          v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
-          v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
+         when NEXT_REG_S =>
+            if regOut.regAck = '0' then
+               v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(r.RegAddr, ADDR_WIDTH_G);
+               v.regIn.regDataSize                      := toslv(Bytes2Read(r.WrdCnt)-1, 2);
 
-          if (R.DelCnt = 0) then
-            v.regIn.regReq := '1';
-            v.state        := READ_ACK_S;
-          else
-            v.DelCnt := r.DelCnt - 1;
-          end if;
-        end if;
+               if (R.DelCnt = 0) then
+                  v.regIn.regReq := '1';
+                  v.state        := READ_ACK_S;
+               else
+                  v.DelCnt := r.DelCnt - 1;
+               end if;
+            end if;
 
-      when FIFO_DEL_S =>
-        v.state := WRITE_DATA_S;
+         when FIFO_DEL_S =>
+            v.state := WRITE_DATA_S;
 
-      when WRITE_DATA_S =>
-        v.regIn.regReq                           := '1';
-        v.regIn.regOp                            := '1';  -- Write operation
-        v.regIn.repeatStart                      := '1';
-        v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(Addr2Write(WAddr), ADDR_WIDTH_G);
-        v.regIn.regDataSize                      := toslv(Bytes2Read(WAddr)-1, 2);
+         when WRITE_DATA_S =>
+            v.regIn.regReq                           := '1';
+            v.regIn.regOp                            := '1';  -- Write operation
+            v.regIn.repeatStart                      := '1';
+            v.regIn.regAddr(ADDR_WIDTH_G-1 downto 0) := toslv(Addr2Write(WAddr), ADDR_WIDTH_G);
+            v.regIn.regDataSize                      := toslv(Bytes2Read(WAddr)-1, 2);
 
-        v.regIn.regWrData := WrData;
-        v.state           := WRITE_ACK_S;
+            v.regIn.regWrData := WrData;
+            v.state           := WRITE_ACK_S;
 
 
-      when WRITE_ACK_S =>
+         when WRITE_ACK_S =>
 
-        -- Wait for completion
-        if regOut.regAck = '1' then
-          -- Reset the flag
-          v.regIn.regReq := '0';
-          -- Check for I2C failure
-          if regOut.regFail = '1' then
-            -- Next state
-            v.state := IDLE_S;
-          else
-            -- Next state
-            v.state := WRITE_DONE_S;
-          end if;
-        end if;
+            -- Wait for completion
+            if regOut.regAck = '1' then
+               -- Reset the flag
+               v.regIn.regReq := '0';
+               -- Check for I2C failure
+               if regOut.regFail = '1' then
+                  -- Next state
+                  v.state := IDLE_S;
+               else
+                  -- Next state
+                  v.state := WRITE_DONE_S;
+               end if;
+            end if;
 
-      when WRITE_DONE_S =>
-        if regOut.regAck = '0' then
-          -- Next state
-          v.state := IDLE_S;
-        end if;
+         when WRITE_DONE_S =>
+            if regOut.regAck = '0' then
+               -- Next state
+               v.state := IDLE_S;
+            end if;
 
-    end case;
+      end case;
 
-    if (Reset = '1') then
-      v := REG_INIT_C;
-    end if;
+      if (Reset = '1') then
+         v := REG_INIT_C;
+      end if;
 
-    rin <= v;
+      rin <= v;
 
-  end process comb;
+   end process comb;
 
-  seq : process (Clock) is
-  begin
-    if (rising_edge(Clock)) then
-      r <= rin after TPD_G;
-    end if;
-  end process seq;
+   seq : process (Clock) is
+   begin
+      if (rising_edge(Clock)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
 
-  U_I2cRegMaster : entity work.I2cRegMaster
-    generic map(
-      TPD_G                => TPD_G,
-      OUTPUT_EN_POLARITY_G => 0,
-      FILTER_G             => FILTER_C,
-      PRESCALE_G           => PRESCALE_C
-      )
-    port map (
-      -- Clock and Reset
-      clk    => clock,
-      srst   => reset,
-      -- I2C Register Interface
-      regIn  => r.regIn,
-      regOut => regOut,
-      -- I2C Port Interface
-      i2ci   => i2ci,
-      i2co   => i2co
-      );
+   U_I2cRegMaster : entity work.I2cRegMaster
+      generic map(
+         TPD_G                => TPD_G,
+         OUTPUT_EN_POLARITY_G => 0,
+         FILTER_G             => FILTER_C,
+         PRESCALE_G           => PRESCALE_C
+         )
+      port map (
+         -- Clock and Reset
+         clk    => clock,
+         srst   => reset,
+         -- I2C Register Interface
+         regIn  => r.regIn,
+         regOut => regOut,
+         -- I2C Port Interface
+         i2ci   => i2ci,
+         i2co   => i2co
+         );
 
-  u_Ram : entity work.SimpleDualPortRam
-    generic map (
-      TPD_G          => 1 ns,           -- Simulated propagation delay 1 ns;
-      RST_POLARITY_G => '1',  -- '1' for active high rst, '0' for active low      
-      BRAM_EN_G      => false,
-      DOB_REG_G      => false,  -- Extra reg on doutb (folded into BRAM)
-      ALTERA_SYN_G   => false,
-      ALTERA_RAM_G   => "M9K",
-      BYTE_WR_EN_G   => false,
-      DATA_WIDTH_G   => 32,
-      BYTE_WIDTH_G   => 8,    -- If BRAM, should be multiple or 8 or 9
-      ADDR_WIDTH_G   => 5,
-      INIT_G         => "0"
-      )
-    port map (
-      -- Port A     
-      clka    => Clock,
-      ena     => '1',
-      wea     => r.StoreWrd,
-      weaByte => "1111",
-      addra   => r.DpRamAddr,
-      dina    => r.ramin,
-      -- Port
-      clkb    => Clock,
-      enb     => '1',
-      rstb    => Reset,
-      addrb   => RdMemAddr(4 downto 0),
-      doutb   => DpDout
-      );
+   u_Ram : entity work.SimpleDualPortRam
+      generic map (
+         TPD_G          => 1 ns,        -- Simulated propagation delay 1 ns;
+         RST_POLARITY_G => '1',         -- '1' for active high rst, '0' for active low      
+         BRAM_EN_G      => false,
+         DOB_REG_G      => false,       -- Extra reg on doutb (folded into BRAM)
+         ALTERA_SYN_G   => false,
+         ALTERA_RAM_G   => "M9K",
+         BYTE_WR_EN_G   => false,
+         DATA_WIDTH_G   => 32,
+         BYTE_WIDTH_G   => 8,           -- If BRAM, should be multiple or 8 or 9
+         ADDR_WIDTH_G   => 5,
+         INIT_G         => "0"
+         )
+      port map (
+         -- Port A     
+         clka    => Clock,
+         ena     => '1',
+         wea     => r.StoreWrd,
+         weaByte => "1111",
+         addra   => r.DpRamAddr,
+         dina    => r.ramin,
+         -- Port
+         clkb    => Clock,
+         enb     => '1',
+         rstb    => Reset,
+         addrb   => RdMemAddr(4 downto 0),
+         doutb   => DpDout
+         );
 
-  u_Fifo : entity work.Fifo
-    generic map (
-      TPD_G           => 1 ns,
-      RST_POLARITY_G  => '1',    -- '1' for active high rst, '0' for active low
-      RST_ASYNC_G     => false,
-      GEN_SYNC_FIFO_G => true,
-      BRAM_EN_G       => true,
-      FWFT_EN_G       => false,
-      USE_DSP48_G     => "no",
-      ALTERA_SYN_G    => false,
-      ALTERA_RAM_G    => "M9K",
-      USE_BUILT_IN_G  => false,  --if set to true, this module is only xilinx compatible only!!!
-      XIL_DEVICE_G    => "7SERIES",     --xilinx only generic parameter    
-      SYNC_STAGES_G   => 3,
-      PIPE_STAGES_G   => 0,
-      DATA_WIDTH_G    => 32,
-      ADDR_WIDTH_G    => 5,
-      INIT_G          => "0",
-      FULL_THRES_G    => 1,
-      EMPTY_THRES_G   => 1
-      )
-    port map (
-      -- Resets
-      rst    => Reset,
-      --Write Ports (wr_clk domain)
-      wr_clk => Clock,
-      wr_en  => WrStrb,
-      din    => FifoDin,
+   u_Fifo : entity work.Fifo
+      generic map (
+         TPD_G           => 1 ns,
+         RST_POLARITY_G  => '1',        -- '1' for active high rst, '0' for active low
+         RST_ASYNC_G     => false,
+         GEN_SYNC_FIFO_G => true,
+         BRAM_EN_G       => true,
+         FWFT_EN_G       => false,
+         USE_DSP48_G     => "no",
+         ALTERA_SYN_G    => false,
+         ALTERA_RAM_G    => "M9K",
+         USE_BUILT_IN_G  => false,  --if set to true, this module is only xilinx compatible only!!!
+         XIL_DEVICE_G    => "7SERIES",  --xilinx only generic parameter    
+         SYNC_STAGES_G   => 3,
+         PIPE_STAGES_G   => 0,
+         DATA_WIDTH_G    => 32,
+         ADDR_WIDTH_G    => 5,
+         INIT_G          => "0",
+         FULL_THRES_G    => 1,
+         EMPTY_THRES_G   => 1
+         )
+      port map (
+         -- Resets
+         rst    => Reset,
+         --Write Ports (wr_clk domain)
+         wr_clk => Clock,
+         wr_en  => WrStrb,
+         din    => FifoDin,
 --      wr_data_count => open,
 --      wr_ack        => open,
 --      overflow      => open,
@@ -414,17 +412,17 @@ begin
 --      almost_full   => open,
 --      full          => open,
 --      not_full      => open,
-      --Read Ports (rd_clk domain)
-      rd_clk => '0',                    --unused if GEN_SYNC_FIFO_G = true
-      rd_en  => r.FifoRdStrb,
-      dout   => FifoDout,
+         --Read Ports (rd_clk domain)
+         rd_clk => '0',                 --unused if GEN_SYNC_FIFO_G = true
+         rd_en  => r.FifoRdStrb,
+         dout   => FifoDout,
 --      rd_data_count => open,
 --      valid         => open,
 --      underflow     => open,
 --      prog_empty    => open,
 --      almost_empty => open,
-      empty  => FifoEmpty
-      );
+         empty  => FifoEmpty
+         );
 
 
 

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -19,5 +19,6 @@ if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMO
 
 # Load ruckus files
 loadSource      -dir "$::DIR_PATH/rtl"
+loadSource      -dir "$::DIR_PATH/rtl/i2c"
 loadConstraints -dir "$::DIR_PATH/xdc"
 


### PR DESCRIPTION
All of these currently live in the lsst-dcpdu project. I've copied them here and cleaned up the formatting.

They could eventually go in surf, but need some cleanup first.

Note that the presense of these modules here will likely break the lsst-dcpdu builds, but it shouldn't be too hard to fix them.