### PR TITLE
adding support for multiple UDP server ports per ETH PHY (default: 4)

### DIFF
--- a/python/LsstPwrCtrlCore/_core.py
+++ b/python/LsstPwrCtrlCore/_core.py
@@ -92,19 +92,23 @@ class LsstPwrCtrlCore(pr.Device):
 
 class LsstPwrCtrlRoot(pr.Root):
     def __init__(self,
-                 hwEmu = False,
-                 sim = False,
-                 rssiEn = False,
-                 ip = '192.168.1.10',
+                 hwEmu    = False,
+                 sim      = False,
+                 rssiEn   = False,
+                 ip       = None,
+                 pollEn   = False,
+                 initRead = True,
                  **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(
+            pollEn   = pollEn,
+            initRead = initRead,
+            **kwargs)
 
         # Check if emulating the GUI interface
         if (hwEmu):
             # Create emulated hardware interface
             print ("Running in Hardware Emulation Mode")
             self.srp = pyrogue.interfaces.simulation.MemEmulate()
-
 
         else:
             # Create srp interface
@@ -126,3 +130,10 @@ class LsstPwrCtrlRoot(pr.Root):
                     udp = rogue.protocols.udp.Client(  ip, 8192, 1500 )
                     # Connect the SRPv3 to UDP
                     pyrogue.streamConnectBiDir(self.srp, udp )
+
+        # Add Core Device
+        self.add(LsstPwrCtrlCore(
+            name    = 'Core',
+            offset  = 0x00000000,
+            memBase = self.srp,
+        ))

--- a/python/LsstPwrCtrlCore/_core.py
+++ b/python/LsstPwrCtrlCore/_core.py
@@ -81,6 +81,14 @@ class LsstPwrCtrlCore(pr.Device):
             mode         = 'RO',
         ))
 
+        self.add(pr.RemoteVariable(
+            name         = 'NUM_PORT_G',
+            description  = 'Number of UDP port per lanes',
+            offset       = AXIL_OFFSETS[7] + 0x410, # 0x1C0410
+            base         = pr.UInt,
+            mode         = 'RO',
+        ))
+
 
 class LsstPwrCtrlRoot(pr.Root):
     def __init__(self,

--- a/python/updateFpgaProm.py
+++ b/python/updateFpgaProm.py
@@ -9,11 +9,9 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-import rogue
 import argparse
 import time
 import os
-import pyrogue         as pr
 import LsstPwrCtrlCore as board
 
 #################################################################

--- a/python/updateFpgaProm.py
+++ b/python/updateFpgaProm.py
@@ -12,6 +12,7 @@
 import rogue
 import argparse
 import time
+import os
 import pyrogue         as pr
 import LsstPwrCtrlCore as board
 
@@ -41,6 +42,11 @@ if __name__ == "__main__":
 
     #################################################################
 
+    # Try to ping the remote device
+    while (os.system("ping -c 1 " + args.ip) != 0):
+        print ( "\nTrying to ping the AMC carrier....\n" )
+        time.sleep(5)
+
     # Set base
     base = board.LsstPwrCtrlRoot(ip=args.ip)
 
@@ -57,10 +63,10 @@ if __name__ == "__main__":
     #################################################################
 
     # Token write to scratchpad to RAW UDP connection
-    AxiVersion._rawWrite(0x4,1)
+    AxiVersion.ScratchPad.post(0x1)
 
     # Unlock the AxiMicronN25Q for PROM erase/programming
-    MicronN25Q._rawWrite(0x0,0xDEADBEEF)
+    MicronN25Q.PasswordLock.set(0xDEADBEEF)
 
     #################################################################
 

--- a/rtl/LsstPwrCtrlCore.vhd
+++ b/rtl/LsstPwrCtrlCore.vhd
@@ -33,7 +33,7 @@ entity LsstPwrCtrlCore is
       SIMULATION_G      : boolean                                      := false;
       BUILD_INFO_G      : BuildInfoType;
       NUM_LANE_G        : positive range 1 to 4                        := 1;
-      NUM_PORT_G        : positive range 1 to 4                        := 2;
+      NUM_PORT_G        : positive range 1 to 4                        := 4;
       AXI_XBAR_CONFIG_G : AxiLiteCrossbarMasterConfigArray(9 downto 0) := genAxiLiteConfig(10, x"0000_0000", 22, 18));
    port (
       -- Register Interface

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -9,7 +9,7 @@ if { [VersionCheck 2017.4 ] < 0 } {
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {ruckus} {3.0.1}  "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}   {2.15.0} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}   {2.19.1} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -8,8 +8,8 @@ if { [VersionCheck 2017.4 ] < 0 } {
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {ruckus} {2.9.0}  "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}   {2.12.3} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus} {3.0.1}  "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}   {2.15.0} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -21,3 +21,6 @@ if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMO
 loadSource -lib lsst_pwr_ctrl_core -dir "$::DIR_PATH/rtl"
 loadSource -lib lsst_pwr_ctrl_core -dir "$::DIR_PATH/rtl/i2c"
 loadConstraints                    -dir "$::DIR_PATH/xdc"
+
+# Updating impl_1 strategy
+set_property strategy Performance_ExplorePostRoutePhysOpt [get_runs impl_1]


### PR DESCRIPTION
### Description
- Updating surf/ruckus submodule locks to latest releases
- adding support for multiple UDP server ports per ETH PHY (default: 4)
  - UDP[0] = Port 8192
  - UDP[1] = Port 8193
  - UDP[2] = Port 8194
  - UDP[3] = Port 8195